### PR TITLE
Updating docs to have ItemPrototype information

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -3,6 +3,7 @@
 ## Class Reference
 
 * [`ItemProtoset`](./item_protoset.md)
+* [`ItemPrototype`](./item_prototype.md)
 * [`InventoryItem`](./inventory_item.md)
 * [`Inventory`](./inventory.md)
 * [`InventoryStacked`](./inventory_stacked.md)

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,9 +1,8 @@
 # Welcome to the GLoot docs!
 
-## Class Reference
+## GDScript Class Reference
 
 * [`ItemProtoset`](./item_protoset.md)
-* [`ItemPrototype`](./item_prototype.md)
 * [`InventoryItem`](./inventory_item.md)
 * [`Inventory`](./inventory.md)
 * [`InventoryStacked`](./inventory_stacked.md)
@@ -12,3 +11,8 @@
 * [`CtrlInventory`](./ctrl_inventory.md)
 * [`CtrlInventoryStacked`](./ctrl_inventory_stacked.md)
 * [`CtrlInventoryGrid`](./ctrl_inventory_grid.md)
+
+## JSON Reference
+
+* [`Item Protoset`](./json_item_protoset.md)
+* [`Item Prototype`](./json_item_prototype.md)

--- a/docs/item_prototype.md
+++ b/docs/item_prototype.md
@@ -1,0 +1,35 @@
+# `ItemPrototype`
+
+Inherits: N/A, JSON
+
+## Description
+
+The prototype data for a given item's definition. These prototypes are expandable and can contain game data, such as item weights, sizes, resource paths, and more. The most barebones format for a single item prototype is the following JSON:
+
+```json
+    {
+        "id": "minimal_item"
+    }
+```
+
+An array of `ItemPrototype`s are utilized inside an [`ItemProtoset`](./item_protoset.md)
+
+## Properties
+
+**Required**
+
+* `id: string` - A string identifier. Must be unique across all item prototypes.
+
+**Optional**
+
+* `name: string` - The name of the item as displayed inside controls.
+* `image: string` - A resource path to a texture to use as the item's image inside controls. Example: `"image": "res://assets/image.png"`
+* `stack_size: int` - Defines the default stack size of the item. Newly created items that use this prototype will have this stack size. Has the value of 1 if not defined.
+* `weight: float` - Defines the unit weight of the item. Has the value of 1.0 if not defined. NOTE: The total weight of an item is defined as its unit weight multiplied by its stack size.
+* `width: int` - Defines the width of the item. Has the value of 1 if not defined.
+* `height: int` - Defines the height of the item. Has the value of 1 if not defined.
+
+The following properties will be used by InventoryStacked: `['image', 'name', 'stack_size', 'weight']`
+The following properties will be used by InventoryGrid: `['image', 'width', 'height']`
+
+In addition to the properties listed above, you can add any bespoke properties for your project's specific needs. See [`InventoryItem`](./inventory_item.md) for usage.

--- a/docs/json_item_protoset.md
+++ b/docs/json_item_protoset.md
@@ -1,0 +1,13 @@
+# `Item Protoset`
+
+Type: JSON
+
+## Description
+
+A simple array of [`Item Prototype (JSON)`](./json_item_prototype.md)s, ready to be parsed by the GDscript class [`ItemProtoset`](./item_protoset.md).
+
+```json
+[
+	// add Item Prototypes here
+]
+```

--- a/docs/json_item_prototype.md
+++ b/docs/json_item_prototype.md
@@ -1,6 +1,6 @@
-# `ItemPrototype`
+# `Item Prototype`
 
-Inherits: N/A, JSON
+Type: JSON
 
 ## Description
 
@@ -12,7 +12,7 @@ The prototype data for a given item's definition. These prototypes are expandabl
     }
 ```
 
-An array of `ItemPrototype`s are utilized inside an [`ItemProtoset`](./item_protoset.md)
+An array of these `Item Prototype`s are utilized inside an [`Item Protoset (JSON)`](./json_item_protoset.md).
 
 ## Properties
 
@@ -29,7 +29,41 @@ An array of `ItemPrototype`s are utilized inside an [`ItemProtoset`](./item_prot
 * `width: int` - Defines the width of the item. Has the value of 1 if not defined.
 * `height: int` - Defines the height of the item. Has the value of 1 if not defined.
 
-The following properties will be used by InventoryStacked: `['image', 'name', 'stack_size', 'weight']`
-The following properties will be used by InventoryGrid: `['image', 'width', 'height']`
+The following properties will be used by [`CtrlInventory`](./ctrl_inventory.md): `['image', 'name']`
+The following properties will be used by [`CtrlInventoryStacked`](./ctrl_inventory_stacked.md): `['image', 'name', 'stack_size', 'weight']`
+The following properties will be used by [`CtrlInventoryGrid`](./ctrl_inventory_grid.md): `['image', 'width', 'height']`
 
 In addition to the properties listed above, you can add any bespoke properties for your project's specific needs. See [`InventoryItem`](./inventory_item.md) for usage.
+
+## Examples
+
+A barebones item for a [`CtrlInventory`](./ctrl_inventory.md):
+
+```json
+    {
+        "id": "minimal_item"
+    }
+```
+
+A 1x1 item with an image for a [`CtrlInventoryGrid`](./ctrl_inventory_grid.md):
+
+```json
+	{
+		"id": "item_with_image",
+		"image": "res://assets/image.png",
+		"width": 1,
+		"height": 1
+	}
+```
+
+A heavy stackable item with an image for a [`CtrlInventoryStacked`](./ctrl_inventory_stacked.md):
+
+```json
+	{
+		"id": "heavy_stackable_item",
+		"name": "Fresh-Cut Timber",
+		"image": "res://assets/image.png",
+		"stack_size": 10,
+		"weight": 500.0
+	}
+```


### PR DESCRIPTION
I added a doc for `ItemPrototype` that has all the properties listed out in the same format as the rest of the docs. Does all of this look correct? (especially the `image` property)