### PR TITLE
[CtrlInventoryStacked] Improved the progress bar

### DIFF
--- a/addons/gloot/ctrl_inventory_stacked.gd
+++ b/addons/gloot/ctrl_inventory_stacked.gd
@@ -3,8 +3,9 @@ extends CtrlInventory
 tool
 
 export(bool) var progress_bar_visible = true setget _set_progress_bar_visible
-export(bool) var percent_visible = true setget _set_percent_visible
+export(bool) var label_visible = true setget _set_label_visible
 var _progress_bar: ProgressBar
+var _label: Label
 
 
 func _set_progress_bar_visible(new_progress_bar_visible: bool) -> void:
@@ -13,18 +14,27 @@ func _set_progress_bar_visible(new_progress_bar_visible: bool) -> void:
         _progress_bar.visible = progress_bar_visible
 
 
-func _set_percent_visible(new_percent_visible: bool) -> void:
-    percent_visible = new_percent_visible
-    if _progress_bar:
-        _progress_bar.percent_visible = percent_visible
+func _set_label_visible(new_label_visible: bool) -> void:
+    label_visible = new_label_visible
+    if _label:
+        _label.visible = label_visible
 
 
 func _ready():
     _progress_bar = ProgressBar.new()
     _progress_bar.size_flags_horizontal = SIZE_EXPAND_FILL
-    _progress_bar.percent_visible = percent_visible
+    _progress_bar.percent_visible = false
     _progress_bar.visible = progress_bar_visible
+    _progress_bar.rect_min_size.y = 20
     add_child(_progress_bar)
+
+    _label = Label.new()
+    _label.anchor_right = 1.0
+    _label.anchor_bottom = 1.0
+    _label.align = ALIGN_CENTER
+    _label.valign = VALIGN_CENTER
+    _progress_bar.add_child(_label)
+
     _refresh()
 
 
@@ -40,8 +50,10 @@ func _disconnect_signals() -> void:
 
 func _refresh():
     ._refresh()
+    if _label:
+        _label.visible = label_visible
+        _label.text = "%d/%d" % [inventory.occupied_space, inventory.capacity]
     if _progress_bar:
-        _progress_bar.percent_visible = percent_visible
         _progress_bar.visible = progress_bar_visible
         _progress_bar.min_value = 0
         _progress_bar.max_value = inventory.capacity


### PR DESCRIPTION
Improved the progress bar in `CtrlInventoryStacked`.
Instead of percentage, it now displays the available space in F/C format (F - free space, C - capacity).