### PR TITLE
fix grid inventory crash if inventory node is above control node

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -49,7 +49,7 @@ func _set_inventory(new_inventory: InventoryGrid) -> void:
     _connect_signals()
 
 
-func _ready():
+func _enter_tree():
     if Engine.editor_hint:
         # Clean up, in case it is duplicated in the editor
         for child in get_children():

--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -49,13 +49,11 @@ func _set_inventory(new_inventory: InventoryGrid) -> void:
     _connect_signals()
 
 
-func _enter_tree():
+func _ready():
     if Engine.editor_hint:
         # Clean up, in case it is duplicated in the editor
         for child in get_children():
             child.queue_free()
-            
-    _set_inventory(get_node_or_null(inventory_path))
 
     _ctrl_item_container = Control.new()
     add_child(_ctrl_item_container)
@@ -65,7 +63,7 @@ func _enter_tree():
     _drag_sprite.z_index = drag_sprite_z_index
     _drag_sprite.hide()
     add_child(_drag_sprite)
-
+    _set_inventory(get_node_or_null(inventory_path))
 
 func _connect_signals() -> void:
     if inventory:


### PR DESCRIPTION
So basically if you put the yellow inventory node above the green inventory node in the scene tree, it would crash because it runs `_populate_list()` before `_ready()` for some reason, and `_ctrl_item_container` is null. (line 140 is where it crashes)

Since `_ctrl_item_container` is constructed on line 60, the function it's in _should_ run before anything else.

`_enter_tree()` is run earlier than `_ready()` so this fixes the issue. I don't think other inventory nodes have this issue.