### PR TITLE
Fix scaling issue in grid inventory

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -148,7 +148,7 @@ func _on_item_grab(ctrl_inventory_item, offset: Vector2) -> void:
             _drag_sprite.texture = default_item_texture
         var item_size = inventory.get_item_size(ctrl_inventory_item.item)
         var texture_size = _drag_sprite.texture.get_size()
-        _drag_sprite.scale = item_size * texture_size / field_dimensions
+        _drag_sprite.scale = item_size * field_dimensions / texture_size
         _drag_sprite.show()
 
 


### PR DESCRIPTION
###  Another thing (two actually),

* First off on line 152 the values were the wrong way around so moving items with a bigger texture than the grid made them look massive. Now they stay the same size when you drag them. (in my private project I also multiplied it by 1.1 so it _pops out_ a bit, another feature maybe?)

* Next, if you pick up a larger (on the grid, not resolution) item it would always place it down exactly where your mouse cursor was. If you picked up the item by the bottom right corner, when you let go it would place it so that the top left corner was under your mouse. 
 Now it remembers the offset of the item (where you clicked) and places it so that the subtile you clicked on remains under your cursor. _Basically it's more responsive and realistic._ You can also use `drag_offset` outside the node so that the same thing happens when transferring items to other inventories.