### PR TITLE
Improve large item dragging in grid inventory

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -159,12 +159,12 @@ func _input(event: InputEvent) -> void:
             mb_event.button_index == BUTTON_LEFT && \
             _grabbed_ctrl_inventory_item:
 
+            var global_grabbed_item_pos = get_global_mouse_position() - _grab_offset + (field_dimensions / 2)
             if _is_mouse_hovering():
-                var field_coords = get_field_coords(get_global_mouse_position())
-                inventory.move_item(_grabbed_ctrl_inventory_item.item, \
-                    field_coords)
+                var field_coords = get_field_coords(global_grabbed_item_pos)
+                inventory.move_item(_grabbed_ctrl_inventory_item.item, field_coords)
             else:
-                emit_signal("item_dropped", _grabbed_ctrl_inventory_item.item, get_global_mouse_position())
+                emit_signal("item_dropped", _grabbed_ctrl_inventory_item.item, global_grabbed_item_pos)
             _grabbed_ctrl_inventory_item.show()
             _grabbed_ctrl_inventory_item = null
             if _drag_sprite:


### PR DESCRIPTION
As mentioned in PR #13 , the code for dragging large items is a bit buggy, it will not always act predictably because the mouse offset is measured in pixels, and depending on _exactly_ where you click on the item will change where it is placed.
As soon as i find a nice solution i will update the commit
It also crashes when transferring to a different inventory