### PR TITLE
Improved grid inventory transfers

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -61,6 +61,7 @@ func _set_inventory(new_inventory: InventoryGrid) -> void:
 
 
 func _ready() -> void:
+	self.add_to_group("Inventory Grid")
     if Engine.editor_hint:
         # Clean up, in case it is duplicated in the editor
         for child in get_children():

--- a/examples/inventory_grid_transfer.gd
+++ b/examples/inventory_grid_transfer.gd
@@ -17,20 +17,25 @@ func _ready() -> void:
 
 
 func _on_item_dropped(item: InventoryItem, drop_pos: Vector2, ctrl_source_inventory: CtrlInventoryGrid) -> void:
-    var ctrl_dest_inventory: CtrlInventoryGrid = null
-    if ctrl_source_inventory == ctrl_inventory_left:
-        ctrl_dest_inventory = ctrl_inventory_right
-    elif ctrl_source_inventory == ctrl_inventory_right:
-        ctrl_dest_inventory = ctrl_inventory_left
-    else:
-        return
+	var ctrl_dest_inventory: CtrlInventoryGrid = null
+	## figure out destination ##
+	var mousePos = get_viewport().get_mouse_position()
+	for node in get_tree().get_nodes_in_group("Inventory Grid"):
+		if node.get_global_rect().has_point(mousePos):
+            #this will cause issues if there are overlaping grids
+            #in different windows, where the most recent one will
+            #be picked
+			ctrl_dest_inventory = node
+			break
+	if ctrl_dest_inventory == null:
+		return #dropped outside of any grid
 
-    var field_coords: Vector2 = ctrl_dest_inventory.get_field_coords(drop_pos)
-    if !ctrl_source_inventory.inventory.transfer_to( \
-            item, \
-            ctrl_dest_inventory.inventory, \
-            field_coords):
-        var slot_rect = ctrl_slot.get_global_rect()
+	var field_coords: Vector2 = ctrl_dest_inventory.get_field_coords(drop_pos)
+	if !ctrl_source_inventory.inventory.transfer_to( \
+        item, \
+        ctrl_dest_inventory.inventory, \
+        field_coords):
+		var slot_rect = ctrl_slot.get_global_rect()
         if slot_rect.has_point(drop_pos) && ctrl_slot.item_slot.can_hold_item(item):
             ctrl_slot.item_slot.item = item
 


### PR DESCRIPTION
I found a better way to do grid inventory transfers. It is more universal and requires less boilerplate code.
When you programmatically generate and instance inventory grids, it's impossible to link them all together.

This way you don't have to worry about individually linking them together, and you can have as many grids as you want, they will all work and transfer item with no extra code.

The only problem left is if there are multiple open inventory grids and they overlap. In that case the oldest one will always be the one that the item is transferred to.