### PR TITLE
[InspectorPlugin] Implementing undo/redo

### DIFF
--- a/addons/gloot/editor/inventory_custom_control.gd
+++ b/addons/gloot/editor/inventory_custom_control.gd
@@ -77,7 +77,7 @@ func _on_inventory_item_activated(item: InventoryItem) -> void:
     var item_data = item.serialize()
     undo_redo.create_action("Remove Inventory Item")
     undo_redo.add_do_method(self, "_remove_item", item_data)
-    undo_redo.add_undo_method(self, "_add_item", item_data)
+    undo_redo.add_undo_method(self, "_add_item", item_data, item.get_index())
     undo_redo.commit_action()
 
 
@@ -114,12 +114,14 @@ func _on_btn_edit() -> void:
 func _on_btn_remove() -> void:
     var selected_items: Array = _inventory_control.get_selected_inventory_items()
     var item_data: Array
+    var item_indexes: Array
     for item in selected_items:
         item_data.append(item.serialize())
+        item_indexes.append(item.get_index())
 
     undo_redo.create_action("Remove Inventory Items")
     undo_redo.add_do_method(self, "_remove_items", item_data)
-    undo_redo.add_undo_method(self, "_add_items", item_data)
+    undo_redo.add_undo_method(self, "_add_items", item_data, item_indexes)
     undo_redo.commit_action()
 
 
@@ -129,15 +131,19 @@ static func _select_node(editor_interface: EditorInterface, node: Node) -> void:
     editor_interface.edit_node(node)
 
 
-func _add_item(item_data: Dictionary) -> void:
+func _add_item(item_data: Dictionary, preferred_index: int = -1) -> void:
     var item = InventoryItem.new()
     item.deserialize(item_data)
     inventory.add_item(item)
+    if preferred_index < 0 || preferred_index >= inventory.get_child_count():
+        return
+        
+    inventory.move_child(item, preferred_index)
 
 
-func _add_items(item_data: Array) -> void:
-    for data in item_data:
-        _add_item(data)
+func _add_items(item_data: Array, item_indexes: Array) -> void:
+    for i in range(item_data.size()):
+        _add_item(item_data[i], item_indexes[i])
 
 
 func _remove_item(item_data: Dictionary) -> void:

--- a/addons/gloot/editor/inventory_inspector_plugin.gd
+++ b/addons/gloot/editor/inventory_inspector_plugin.gd
@@ -7,6 +7,7 @@ var ItemPropertyEditor = preload("res://addons/gloot/editor/item_property_editor
 var ItemPrototypeIdEditor = preload("res://addons/gloot/editor/item_prototype_id_editor.gd")
 var ItemSlotEquippedItemEditor = preload("res://addons/gloot/editor/item_slot_equipped_item_editor.gd")
 var editor_interface: EditorInterface = null
+var undo_redo: UndoRedo = null
 
 
 func can_handle(object: Object) -> bool:
@@ -24,14 +25,17 @@ func parse_begin(object: Object) -> void:
 func parse_property(object, type, path, hint, hint_text, usage) -> bool:
     if (object is InventoryItem) && path == "properties":
         var item_property_editor =ItemPropertyEditor.new()
+        item_property_editor.undo_redo = undo_redo
         add_property_editor(path, item_property_editor)
         return true
     if (object is InventoryItem) && path == "prototype_id":
         var item_prototype_id_editor =ItemPrototypeIdEditor.new()
+        item_prototype_id_editor.undo_redo = undo_redo
         add_property_editor(path, item_prototype_id_editor)
         return true
     if (object is ItemSlot) && path == "equipped_item":
         var item_slot_equipped_item_editor =ItemSlotEquippedItemEditor.new()
+        item_slot_equipped_item_editor.undo_redo = undo_redo
         add_property_editor(path, item_slot_equipped_item_editor)
         return true
     return false

--- a/addons/gloot/editor/inventory_inspector_plugin.gd
+++ b/addons/gloot/editor/inventory_inspector_plugin.gd
@@ -19,6 +19,7 @@ func parse_begin(object: Object) -> void:
         var inventory_custom_control = InventoryCustomControl.instance()
         inventory_custom_control.inventory = object
         inventory_custom_control.editor_interface = editor_interface
+        inventory_custom_control.undo_redo = undo_redo
         add_custom_control(inventory_custom_control)
 
 

--- a/addons/gloot/editor/item_prototype_id_editor.gd
+++ b/addons/gloot/editor/item_prototype_id_editor.gd
@@ -9,6 +9,7 @@ var updating: bool = false
 var _choice_filter: Control
 var _window_dialog: WindowDialog
 var _btn_prototype_id: Button
+var undo_redo: UndoRedo = null
 
 
 func _init() -> void:
@@ -42,6 +43,8 @@ func _init() -> void:
 
 
 func _ready() -> void:
+    var item: InventoryItem = get_edited_object()
+    item.connect("prototype_id_changed", self, "_on_prototype_id_changed")
     _refresh_button()
 
 
@@ -51,8 +54,20 @@ func _on_btn_prototype_id() -> void:
 
 func _on_choice_picked(value_index: int) -> void:
     var item: InventoryItem = get_edited_object()
-    item.prototype_id = _choice_filter.values[value_index]
+    var new_prototype_id = _choice_filter.values[value_index]
+    if new_prototype_id == item.prototype_id:
+        return
+
+    undo_redo.create_action("Set prototype_id")
+    undo_redo.add_undo_property(item, "prototype_id", item.prototype_id)
+    undo_redo.add_do_property(item, "prototype_id", new_prototype_id)
+    undo_redo.commit_action()
+
     _window_dialog.hide()
+    _refresh_button()
+
+
+func _on_prototype_id_changed() -> void:
     _refresh_button()
 
 

--- a/addons/gloot/gloot.gd
+++ b/addons/gloot/gloot.gd
@@ -22,6 +22,7 @@ func _enter_tree():
 
     inspector_plugin = preload("res://addons/gloot/editor/inventory_inspector_plugin.gd").new()
     inspector_plugin.editor_interface = get_editor_interface()
+    inspector_plugin.undo_redo = get_undo_redo()
     add_inspector_plugin(inspector_plugin)
 
 

--- a/addons/gloot/inventory.gd
+++ b/addons/gloot/inventory.gd
@@ -66,6 +66,25 @@ func _on_item_removed(item: InventoryItem) -> void:
     _disconnect_item_signals(item)
 
 
+func move_child(child_node: Node, to_position: int) -> void:
+    _move_item(child_node.get_index(), to_position)
+    .move_child(child_node, to_position)
+    emit_signal("contents_changed")
+
+
+func _move_item(from: int, to: int) -> void:
+    assert(from >= 0)
+    assert(from < _items.size())
+    assert(to >= 0)
+    assert(to < _items.size())
+    if from == to:
+        return
+
+    var item = _items[from]
+    _items.remove(from)
+    _items.insert(to, item)
+
+
 func _connect_item_signals(item: InventoryItem) -> void:
     if !item.is_connected("protoset_changed", self, "_emit_item_modified"):
         item.connect("protoset_changed", self, "_emit_item_modified", [item])

--- a/addons/gloot/inventory.gd
+++ b/addons/gloot/inventory.gd
@@ -11,6 +11,7 @@ signal protoset_changed
 export(Resource) var item_protoset: Resource setget _set_item_protoset
 var _items: Array = []
 
+const KEY_NODE_NAME: String = "node_name"
 const KEY_ITEM_PROTOSET: String = "item_protoset"
 const KEY_ITEMS: String = "items"
 
@@ -155,6 +156,7 @@ func clear() -> void:
 func serialize() -> Dictionary:
     var result: Dictionary = {}
 
+    result[KEY_NODE_NAME] = name
     result[KEY_ITEM_PROTOSET] = item_protoset.resource_path
     if !get_items().empty():
         result[KEY_ITEMS] = []
@@ -165,12 +167,14 @@ func serialize() -> Dictionary:
 
 
 func deserialize(source: Dictionary) -> bool:
-    if !GlootVerify.dict(source, true, KEY_ITEM_PROTOSET, TYPE_STRING) ||\
+    if !GlootVerify.dict(source, true, KEY_NODE_NAME, TYPE_STRING) ||\
+        !GlootVerify.dict(source, true, KEY_ITEM_PROTOSET, TYPE_STRING) ||\
         !GlootVerify.dict(source, false, KEY_ITEMS, TYPE_ARRAY, TYPE_DICTIONARY):
         return false
 
     reset()
 
+    name = source[KEY_NODE_NAME]
     item_protoset = load(source[KEY_ITEM_PROTOSET])
     if source.has(KEY_ITEMS):
         var items = source[KEY_ITEMS]

--- a/addons/gloot/inventory_item.gd
+++ b/addons/gloot/inventory_item.gd
@@ -14,6 +14,8 @@ var _inventory: Node
 const KEY_PROTOSET: String = "protoset"
 const KEY_PROTOTYE_ID: String = "prototype_id"
 const KEY_PROPERTIES: String = "properties"
+const KEY_NODE_NAME: String = "node_name"
+
 const KEY_IMAGE: String = "image"
 const KEY_NAME: String = "name"
 
@@ -101,6 +103,7 @@ func reset() -> void:
 func serialize() -> Dictionary:
     var result: Dictionary = {}
 
+    result[KEY_NODE_NAME] = name
     result[KEY_PROTOSET] = protoset.resource_path
     result[KEY_PROTOTYE_ID] = prototype_id
     if !properties.empty():
@@ -110,13 +113,15 @@ func serialize() -> Dictionary:
 
 
 func deserialize(source: Dictionary) -> bool:
-    if !GlootVerify.dict(source, true, KEY_PROTOSET, TYPE_STRING) ||\
+    if !GlootVerify.dict(source, true, KEY_NODE_NAME, TYPE_STRING) ||\
+        !GlootVerify.dict(source, true, KEY_PROTOSET, TYPE_STRING) ||\
         !GlootVerify.dict(source, true, KEY_PROTOTYE_ID, TYPE_STRING) ||\
         !GlootVerify.dict(source, false, KEY_PROPERTIES, TYPE_DICTIONARY):
         return false
 
     reset()
 
+    name = source[KEY_NODE_NAME]
     protoset = load(source[KEY_PROTOSET])
     prototype_id = source[KEY_PROTOTYE_ID]
     if source.has(KEY_PROPERTIES):

--- a/examples/inventory_grid_transfer.tscn
+++ b/examples/inventory_grid_transfer.tscn
@@ -132,8 +132,6 @@ properties = {
 script = ExtResource( 8 )
 protoset = ExtResource( 1 )
 prototype_id = "item_2x2"
-properties = {
-}
 
 [node name="InventoryGridRight" type="Node" parent="."]
 script = ExtResource( 2 )
@@ -152,8 +150,6 @@ properties = {
 script = ExtResource( 8 )
 protoset = ExtResource( 1 )
 prototype_id = "item_1x1"
-properties = {
-}
 
 [node name="ItemSlot" type="Node" parent="."]
 script = ExtResource( 7 )

--- a/examples/inventory_transfer.tscn
+++ b/examples/inventory_transfer.tscn
@@ -112,15 +112,11 @@ item_protoset = ExtResource( 3 )
 script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "item1"
-properties = {
-}
 
 [node name="InventoryItem2" type="Node" parent="Inventory"]
 script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "item2"
-properties = {
-}
 
 [node name="Inventory2" type="Node" parent="."]
 script = ExtResource( 2 )
@@ -130,15 +126,11 @@ item_protoset = ExtResource( 3 )
 script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "item1"
-properties = {
-}
 
 [node name="InventoryItem4" type="Node" parent="Inventory2"]
 script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "item2"
-properties = {
-}
 
 [node name="ItemSlot" type="Node" parent="."]
 script = ExtResource( 7 )

--- a/tests/gloot_test.tscn
+++ b/tests/gloot_test.tscn
@@ -33,15 +33,11 @@ item_protoset = ExtResource( 9 )
 script = ExtResource( 13 )
 protoset = ExtResource( 9 )
 prototype_id = "minimal_item"
-properties = {
-}
 
 [node name="MinimalItem2" type="Node" parent="ItemDefinitionsTest/Inventory"]
 script = ExtResource( 13 )
 protoset = ExtResource( 9 )
 prototype_id = "minimal_item"
-properties = {
-}
 
 [node name="InventoryTests" type="Node" parent="."]
 script = ExtResource( 6 )
@@ -54,8 +50,6 @@ item_protoset = ExtResource( 9 )
 script = ExtResource( 13 )
 protoset = ExtResource( 9 )
 prototype_id = "minimal_item"
-properties = {
-}
 
 [node name="Inventory2" type="Node" parent="InventoryTests"]
 script = ExtResource( 11 )
@@ -73,22 +67,16 @@ capacity = 10.0
 script = ExtResource( 13 )
 protoset = ExtResource( 8 )
 prototype_id = "minimal_item"
-properties = {
-}
 
 [node name="StackableItem" type="Node" parent="InventoryStackedTests"]
 script = ExtResource( 13 )
 protoset = ExtResource( 8 )
 prototype_id = "stackable_item"
-properties = {
-}
 
 [node name="BigItem" type="Node" parent="InventoryStackedTests"]
 script = ExtResource( 13 )
 protoset = ExtResource( 8 )
 prototype_id = "big_item"
-properties = {
-}
 
 [node name="InventoryGridTests" type="Node" parent="."]
 script = ExtResource( 5 )
@@ -102,15 +90,11 @@ size = Vector2( 3, 3 )
 script = ExtResource( 13 )
 protoset = ExtResource( 7 )
 prototype_id = "item_1x1"
-properties = {
-}
 
 [node name="Item_2x2" type="Node" parent="InventoryGridTests"]
 script = ExtResource( 13 )
 protoset = ExtResource( 7 )
 prototype_id = "item_2x2"
-properties = {
-}
 
 [node name="ItemSlotTests" type="Node" parent="."]
 script = ExtResource( 4 )
@@ -123,8 +107,6 @@ item_protoset = ExtResource( 9 )
 script = ExtResource( 13 )
 protoset = ExtResource( 9 )
 prototype_id = "minimal_item"
-properties = {
-}
 
 [node name="Inventory2" type="Node" parent="ItemSlotTests"]
 script = ExtResource( 11 )


### PR DESCRIPTION
Implemented undo/redo for the following operations when executed via the inspector plugin:
* Adding/removing items
* Setting the equipped item for an `ItemSlot`
* Changing `InventoryItem` properties
* Changing `InventoryItem` `prototype_id`