### PR TITLE
[Inspector] Additional configuration checks

### DIFF
--- a/addons/gloot/editor/inventory_editor.gd
+++ b/addons/gloot/editor/inventory_editor.gd
@@ -39,6 +39,10 @@ func connect_inventory_signals():
         inventory.connect("size_changed", self, "_refresh")
     inventory.connect("protoset_changed", self, "_refresh")
 
+    if !inventory.item_protoset:
+        return
+    inventory.item_protoset.connect("changed", self, "_refresh")
+
 
 func disconnect_inventory_signals():
     if !inventory:
@@ -49,6 +53,10 @@ func disconnect_inventory_signals():
     if inventory is InventoryGrid:
         inventory.disconnect("size_changed", self, "_refresh")
     inventory.disconnect("protoset_changed", self, "_refresh")
+
+    if !inventory.item_protoset:
+        return
+    inventory.item_protoset.disconnect("changed", self, "_refresh")
 
 
 func _refresh() -> void:

--- a/addons/gloot/editor/item_prototype_id_editor.gd
+++ b/addons/gloot/editor/item_prototype_id_editor.gd
@@ -5,6 +5,7 @@ const ChoiceFilter = preload("res://addons/gloot/editor/choice_filter.tscn")
 const EditorIcons = preload("res://addons/gloot/editor/editor_icons.gd")
 const POPUP_SIZE = Vector2(300, 300)
 const POPUP_MARGIN = 10
+const COLOR_INVALID = Color.red
 var current_value: String
 var updating: bool = false
 var _choice_filter: Control
@@ -48,6 +49,8 @@ func _ready() -> void:
     _choice_filter.filter_icon = EditorIcons.get_icon(editor_interface, "Search")
     var item: InventoryItem = get_edited_object()
     item.connect("prototype_id_changed", self, "_on_prototype_id_changed")
+    if item.protoset:
+        item.protoset.connect("changed", self, "_on_protoset_changed")
     _refresh_button()
 
 
@@ -67,6 +70,11 @@ func _on_choice_picked(value_index: int) -> void:
 
 func _on_prototype_id_changed() -> void:
     _refresh_button()
+
+
+func _on_protoset_changed() -> void:
+    _refresh_button()
+    _refresh_choice_filter()
 
 
 func update_property() -> void:
@@ -89,6 +97,10 @@ func _refresh_choice_filter() -> void:
 func _refresh_button() -> void:
     var item: InventoryItem = get_edited_object()
     _btn_prototype_id.text = item.prototype_id
+    if !item.protoset.has(item.prototype_id):
+        _btn_prototype_id.add_color_override("font_color", COLOR_INVALID)
+    else:
+        _btn_prototype_id.remove_color_override("font_color")
 
 
 func _get_prototype_ids() -> Array:

--- a/addons/gloot/editor/item_prototype_id_editor.gd
+++ b/addons/gloot/editor/item_prototype_id_editor.gd
@@ -99,8 +99,12 @@ func _refresh_button() -> void:
     _btn_prototype_id.text = item.prototype_id
     if !item.protoset.has(item.prototype_id):
         _btn_prototype_id.add_color_override("font_color", COLOR_INVALID)
+        _btn_prototype_id.add_color_override("font_color_hover", COLOR_INVALID)
+        _btn_prototype_id.hint_tooltip = "Invalid prototype ID!"
     else:
         _btn_prototype_id.remove_color_override("font_color")
+        _btn_prototype_id.remove_color_override("font_color_hover")
+        _btn_prototype_id.hint_tooltip = ""
 
 
 func _get_prototype_ids() -> Array:

--- a/addons/gloot/inventory_item.gd
+++ b/addons/gloot/inventory_item.gd
@@ -30,7 +30,7 @@ func _get_configuration_warning() -> String:
         return ""
 
     if !protoset.has(prototype_id):
-        return "Undefined prototype '%s'. Check the protoset!" % prototype_id
+        return "Undefined prototype '%s'. Check the item protoset!" % prototype_id
 
     return ""
 

--- a/addons/gloot/inventory_item.gd
+++ b/addons/gloot/inventory_item.gd
@@ -25,6 +25,16 @@ const KEY_NAME: String = "name"
 const Verify = preload("res://addons/gloot/verify.gd")
 
 
+func _get_configuration_warning() -> String:
+    if !protoset:
+        return ""
+
+    if !protoset.has(prototype_id):
+        return "Undefined prototype '%s'. Check the protoset!" % prototype_id
+
+    return ""
+
+
 func _set_prototset(new_protoset: Resource) -> void:
     var old_protoset = protoset
     protoset = new_protoset
@@ -34,7 +44,10 @@ func _set_prototset(new_protoset: Resource) -> void:
         if protoset && protoset._prototypes && protoset._prototypes.keys().size() > 0:
             _set_prototype_id(protoset._prototypes.keys()[0])
 
+        protoset.connect("changed", self, "_on_protoset_modified")
+
         emit_signal("protoset_changed")
+        update_configuration_warning()
 
 
 func _set_prototype_id(new_prototype_id: String) -> void:
@@ -43,11 +56,17 @@ func _set_prototype_id(new_prototype_id: String) -> void:
     if old_prototype_id != prototype_id:
         reset_properties()
         emit_signal("prototype_id_changed")
+        update_configuration_warning()
 
 
 func _set_properties(new_properties: Dictionary) -> void:
     properties = new_properties
     emit_signal("properties_changed")
+    update_configuration_warning()
+
+
+func _on_protoset_modified() -> void:
+    update_configuration_warning()
 
 
 func reset_properties() -> void:

--- a/addons/gloot/item_protoset.gd
+++ b/addons/gloot/item_protoset.gd
@@ -13,6 +13,7 @@ func _set_json_data(new_json_data: String) -> void:
     json_data = new_json_data
     if !json_data.empty():
         parse(json_data)
+    emit_changed()
 
 
 func parse(json: String) -> void:

--- a/addons/gloot/item_slot.gd
+++ b/addons/gloot/item_slot.gd
@@ -17,8 +17,16 @@ const KEY_ITEM: String = "item"
 const Verify = preload("res://addons/gloot/verify.gd")
 
 
+func _get_configuration_warning() -> String:
+    if inventory_path.is_empty():
+        return "Inventory path not set! Inventory path needs to point to an inventory node, so " +\
+        "items from that inventory can be equipped in the slot."
+    return ""
+
+
 func _set_inventory_path(new_inv_path: NodePath) -> void:
     inventory_path = new_inv_path
+    update_configuration_warning()
     var node: Node = get_node_or_null(inventory_path)
 
     if is_inside_tree() && node:


### PR DESCRIPTION
Added some checks to cover some cases where the protoset is modified without any changes to the `Inventory` or `InventoryItem` that use said protoset. These include additional configuration warnings and highlighting invalid fields in the inspector.