### PR TITLE
[InventoryGrid] add controller and keyboard support

### DIFF
--- a/addons/gloot/ctrl_inventory_item_rect.gd
+++ b/addons/gloot/ctrl_inventory_item_rect.gd
@@ -9,6 +9,7 @@ var ctrl_inventory
 var texture: Texture setget _set_texture
 var selected: bool = false setget _set_selected
 var selection_bg_color: Color = Color.gray setget _set_selection_bg_color
+var focus_color : Color = Color.yellowgreen
 
 
 func _set_texture(new_texture: Texture) -> void:
@@ -75,8 +76,13 @@ func _get_item_position() -> Vector2:
 
 func _ready() -> void:
     if item && ctrl_inventory:
+        focus_mode = Control.FOCUS_ALL
+        grab_focus()
         _refresh()
 
+func cancel_drag() -> void:
+    focus_mode = Control.FOCUS_ALL
+    grab_focus()
 
 func _draw() -> void:
     var rect = Rect2(Vector2.ZERO, rect_size)
@@ -90,8 +96,18 @@ func _draw() -> void:
     else:
         draw_rect(rect, Color.white, false)
 
+    if has_focus():
+        draw_rect(rect, focus_color, false)
 
 func _input(event: InputEvent) -> void:
+    if has_focus():
+        if event.is_action_pressed("ui_select"):
+            emit_signal("activated", self)
+        elif event.is_action_pressed("ui_accept"):
+            emit_signal("grabbed", self, Vector2(5,5), true)
+            focus_mode = Control.FOCUS_NONE
+
+
     if !(event is InputEventMouseButton):
         return
 
@@ -105,4 +121,5 @@ func _input(event: InputEvent) -> void:
     elif mb_event.is_pressed():
         if get_global_rect().has_point(get_global_mouse_position()):
             var offset: Vector2 = get_global_mouse_position() - get_global_rect().position
-            emit_signal("grabbed", self, offset)
+            emit_signal("grabbed", self, offset, false)
+            focus_mode = Control.FOCUS_NONE

--- a/addons/gloot/gloot_autoload.gd
+++ b/addons/gloot/gloot_autoload.gd
@@ -1,6 +1,8 @@
 extends Node
 
-signal item_dropped
+signal item_grabbed(item)
+signal item_dropped(item, position)
+signal grab_canceled(item)
 
 var _grabbed_inventory_item: Node
 var _grab_offset: Vector2


### PR DESCRIPTION
Hey, I needed to add controller & keyboard support to the grid ctrls, and I thought I drop off my changes here.

I'm using the default `ui_` actions that godot generates for every new project, so I guess it's fair to assume they are there.
One thing that might be contestable imo is using `grab_focus()` on `ctrl_inventory_item_rect` to auto focus the latest item at the start and give it back focus when it is dropped. Maybe you want to remove that line, but it comes in very handy for me.

I also added some more signals to the autoload class, so I can rotate and reset rotation from my game's code.

[controller-ctrls.webm](https://user-images.githubusercontent.com/560561/203133427-7e5e0e59-87b3-4489-b72e-8e125cf1d370.webm)



If anyone is interested, here is the code I use in my game for rotation and switching between grids:

```gdscript
extends Control
onready var grid_left = $"%CtrlInventoryGridEx_left"
onready var grid_right = $"%CtrlInventoryGridEx_right"

var last_grab_item = null
var last_grab_item_rotation = false

func _ready():
        GLoot.connect("item_grabbed", self, "on_item_grabbed")
        GLoot.connect("grab_canceled", self, "on_grab_canceled")


func _on_CtrlInventoryGridEx_left_virtual_cursor_moved_outside(grid, direction):
        switch_grid(grid, direction)

func _on_CtrlInventoryGridEx_right_virtual_cursor_moved_outside(grid, direction):
        switch_grid(grid, direction)

func switch_grid(grid, direction):
        if grid == grid_left and direction.x >= 1.0:
                print("move the cursor to the right")
                grid_left.switch_virtual_cursor_grid(grid_right)
                grid_right.switch_virtual_cursor_grid(grid_right)
        elif grid == grid_right and direction.x <= -1.0:
                print("move the cursor to the left")
                grid_left.switch_virtual_cursor_grid(grid_left)
                grid_right.switch_virtual_cursor_grid(grid_left)

func _input(event):
        if event.is_action_released("rotate_item") and GLoot._grabbed_inventory_item:
                var old_rotation = GLoot._grabbed_inventory_item.get_property("rotated", false)
                GLoot._grabbed_inventory_item.set_property("rotated", !old_rotation)

func on_item_grabbed(item):
        last_grab_item = item
        last_grab_item_rotation = item.get_property("rotated", false)

func on_grab_canceled(item):
        if item == last_grab_item:
                last_grab_item_rotation = item.set_property("rotated", last_grab_item_rotation)
```

I hope this is helpful.
