### PR TITLE
Signaling mouse hovers

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -4,6 +4,8 @@ tool
 
 signal item_dropped
 signal inventory_item_activated
+signal item_mouse_entered(item)
+signal item_mouse_exited(item)
 
 export(Vector2) var field_dimensions: Vector2 = Vector2(32, 32) setget _set_field_dimensions
 export(int) var item_spacing: int = 0 setget _set_item_spacing
@@ -252,6 +254,8 @@ func _populate_list() -> void:
         ctrl_inventory_item.item = item
         ctrl_inventory_item.connect("grabbed", self, "_on_item_grab")
         ctrl_inventory_item.connect("activated", self, "_on_item_activated")
+        ctrl_inventory_item.connect("mouse_entered", self, "_on_item_mouse_entered", [ctrl_inventory_item])
+        ctrl_inventory_item.connect("mouse_exited", self, "_on_item_mouse_exited", [ctrl_inventory_item])
         _ctrl_item_container.add_child(ctrl_inventory_item)
 
     _refresh_selection()
@@ -308,6 +312,14 @@ func _on_item_activated(ctrl_inventory_item) -> void:
         _drag_sprite.hide()
 
     emit_signal("inventory_item_activated", item)
+
+
+func _on_item_mouse_entered(ctrl_inventory_item) -> void:
+    emit_signal("item_mouse_entered", ctrl_inventory_item.item)
+
+
+func _on_item_mouse_exited(ctrl_inventory_item) -> void:
+    emit_signal("item_mouse_exited", ctrl_inventory_item.item)
 
 
 func _select(item: InventoryItem) -> void:

--- a/docs/ctrl_inventory_grid.md
+++ b/docs/ctrl_inventory_grid.md
@@ -27,4 +27,7 @@ A UI control representing a grid based inventory (`InventoryGrid`). Displays a g
 
 ## Signals
 
-* `item_dropped(InventoryItem, Vector2)` - Emitted when a grabbed `CtrlInventoryItemRect` is dropped.
+* `item_dropped(InventoryItem, Vector2)` - Emitted when a grabbed `InventoryItem` is dropped.
+* `inventory_item_activated(InventoryItem)` - Emitted when an `InventoryItem` is activated (i.e. double clicked).
+* `item_mouse_entered(InventoryItem)` - Emitted when the mouse enters the `Rect` area of the control representing the given `InventoryItem`.
+* `item_mouse_entered(InventoryItem)` - Emitted when the mouse leaves the `Rect` area of the control representing the given `InventoryItem`.

--- a/examples/inventory_grid_ex_transfer.tscn
+++ b/examples/inventory_grid_ex_transfer.tscn
@@ -206,3 +206,8 @@ prototype_id = "item_1x1"
 [node name="ItemSlot" type="Node" parent="."]
 script = ExtResource( 7 )
 inventory_path = NodePath("../InventoryGridRight")
+
+[node name="LblInfo" type="Label" parent="."]
+visible = false
+margin_right = 40.0
+margin_bottom = 14.0

--- a/examples/inventory_grid_transfer.gd
+++ b/examples/inventory_grid_transfer.gd
@@ -1,17 +1,40 @@
 extends Control
 
+const info_offset: Vector2 = Vector2(20, 0)
+
 onready var ctrl_inventory_left: CtrlInventoryGrid = $VBoxContainer/HBoxContainer/VBoxContainer/PanelContainer/CtrlInventoryGridLeft
 onready var ctrl_inventory_right: CtrlInventoryGrid = $VBoxContainer/HBoxContainer/VBoxContainer2/PanelContainer2/CtrlInventoryGridRight
 onready var btn_sort_left: Button = $VBoxContainer/HBoxContainer/VBoxContainer/BtnSortLeft
 onready var btn_sort_right: Button = $VBoxContainer/HBoxContainer/VBoxContainer2/BtnSortRight
 onready var ctrl_slot: CtrlItemSlot = $VBoxContainer/HBoxContainer/VBoxContainer3/PanelContainer/CtrlItemSlot
 onready var btn_unequip: Button = $VBoxContainer/HBoxContainer/VBoxContainer3/BtnUnequip
+onready var lbl_info: Label = $LblInfo
 
 
 func _ready() -> void:
+    ctrl_inventory_left.connect("item_mouse_entered", self, "_on_item_mouse_entered")
+    ctrl_inventory_left.connect("item_mouse_exited", self, "_on_item_mouse_exited")
+    ctrl_inventory_right.connect("item_mouse_entered", self, "_on_item_mouse_entered")
+    ctrl_inventory_right.connect("item_mouse_exited", self, "_on_item_mouse_exited")
     btn_sort_left.connect("pressed", self, "_on_btn_sort", [ctrl_inventory_left])
     btn_sort_right.connect("pressed", self, "_on_btn_sort", [ctrl_inventory_right])
     btn_unequip.connect("pressed", self, "_on_btn_unequip")
+
+
+func _on_item_mouse_entered(item: InventoryItem) -> void:
+    lbl_info.show()
+    lbl_info.text = item.prototype_id
+
+
+func _on_item_mouse_exited(_item: InventoryItem) -> void:
+    lbl_info.hide()
+
+
+func _input(event: InputEvent) -> void:
+    if !(event is InputEventMouseMotion):
+        return
+
+    lbl_info.set_global_position(get_global_mouse_position() + info_offset)
 
 
 func _on_btn_sort(ctrl_inventory: CtrlInventoryGrid) -> void:

--- a/examples/inventory_grid_transfer.tscn
+++ b/examples/inventory_grid_transfer.tscn
@@ -154,3 +154,8 @@ prototype_id = "item_1x1"
 [node name="ItemSlot" type="Node" parent="."]
 script = ExtResource( 7 )
 inventory_path = NodePath("../InventoryGridRight")
+
+[node name="LblInfo" type="Label" parent="."]
+visible = false
+margin_right = 40.0
+margin_bottom = 14.0

--- a/tests/data/item_definitions_grid.tres
+++ b/tests/data/item_definitions_grid.tres
@@ -9,12 +9,12 @@ json_data = "[
         \"id\": \"item_1x1\",
         \"width\": 1,
         \"height\": 1,
-		\"image\": \"res://images/item_book_blue.png\"
+        \"image\": \"res://images/item_book_blue.png\"
     },
     {
         \"id\": \"item_2x2\",
         \"width\": 2,
         \"height\": 2,
-		\"image\": \"res://images/item_armour_silver.png\"
+        \"image\": \"res://images/item_armour_silver.png\"
     }
 ]"


### PR DESCRIPTION
Added `mouse_entered_item(item)` and `mouse_exited_item(item)` signals to the `CtrlInventoryGrid` class, as described in https://github.com/peter-kish/gloot/issues/70.