### PR TITLE
Introducing `max_stack_size` property for `InventoryStacked`

### DIFF
--- a/addons/gloot/inventory.gd
+++ b/addons/gloot/inventory.gd
@@ -170,6 +170,16 @@ func get_item_by_id(prototype_id: String) -> InventoryItem:
     return null
 
 
+func get_items_by_id(prototype_id: String) -> Array:
+    var result := []
+
+    for item in get_items():
+        if item.prototype_id == prototype_id:
+            result.append(item)
+            
+    return result
+
+
 func has_item_by_id(prototype_id: String) -> bool:
     return get_item_by_id(prototype_id) != null
 

--- a/addons/gloot/inventory_stacked.gd
+++ b/addons/gloot/inventory_stacked.gd
@@ -137,12 +137,12 @@ func _get_item_weight(item: InventoryItem) -> float:
 
 func add_item(item: InventoryItem) -> bool:
     if has_place_for(item):
-        return _add_item_automerge(item)
+        return .add_item(item)
 
     return false
 
 
-func _add_item_automerge(item: InventoryItem) -> bool:
+func add_item_automerge(item: InventoryItem) -> bool:
     if !has_place_for(item):
         return false
 
@@ -154,7 +154,7 @@ func _add_item_automerge(item: InventoryItem) -> bool:
             _calculate_occupied_space()
             if item.get_inventory():
                 item.get_inventory().remove_item(item)
-            item.queue_free()
+            item.free()
             return true
 
     .add_item(item)
@@ -234,7 +234,7 @@ func transfer_autosplit(item: InventoryItem, destination: Inventory) -> bool:
 
 func transfer_automerge(item: InventoryItem, destination: Inventory) -> bool:
     if destination.has_place_for(item) && remove_item(item):
-        return destination._add_item_automerge(item)
+        return destination.add_item_automerge(item)
 
     return false
 

--- a/addons/gloot/inventory_stacked.gd
+++ b/addons/gloot/inventory_stacked.gd
@@ -7,7 +7,10 @@ signal occupied_space_changed
 
 const KEY_WEIGHT: String = "weight"
 const KEY_STACK_SIZE: String = "stack_size"
+const KEY_MAX_STACK_SIZE: String = "max_stack_size"
+
 const DEFAULT_STACK_SIZE: int = 1
+const DEFAULT_MAX_STACK_SIZE: int = 100
 
 export(float) var capacity: float setget _set_capacity
 var occupied_space: float setget _set_occupied_space
@@ -118,6 +121,10 @@ func _get_item_stack_size(item: InventoryItem) -> int:
     return item.get_property(KEY_STACK_SIZE, DEFAULT_STACK_SIZE)
 
 
+func _get_item_max_stack_size(item: InventoryItem) -> int:
+    return item.get_property(KEY_MAX_STACK_SIZE, DEFAULT_MAX_STACK_SIZE)
+
+
 func _set_item_stack_size(item: InventoryItem, stack_size: int) -> void:
     item.set_property(KEY_STACK_SIZE, stack_size)
 
@@ -130,7 +137,7 @@ func _get_item_weight(item: InventoryItem) -> float:
 
 func add_item(item: InventoryItem) -> bool:
     if has_place_for(item):
-        return .add_item(item)
+        return _add_item_automerge(item)
 
     return false
 
@@ -139,13 +146,38 @@ func _add_item_automerge(item: InventoryItem) -> bool:
     if !has_place_for(item):
         return false
 
-    var target_item = get_item_by_id(item.prototype_id)
-    if target_item:
-        add_item(item)
-        join(target_item, item)
-        return true
-    else:
-        return add_item(item)
+    var target_items = get_items_by_id(item.prototype_id)
+    target_items.sort_custom(self, "_compare_items_by_stack_size")
+    for target_item in target_items:
+        _merge_stacks(item, target_item)
+        if _get_item_stack_size(item) <= 0:
+            _calculate_occupied_space()
+            if item.get_inventory():
+                item.get_inventory().remove_item(item)
+            item.queue_free()
+            return true
+
+    .add_item(item)
+    return true
+
+
+func _compare_items_by_stack_size(a: InventoryItem, b: InventoryItem) -> bool:
+    return _get_item_stack_size(a) < _get_item_stack_size(b)
+
+
+func _merge_stacks(item_src: InventoryItem, item_dst: InventoryItem) -> void:
+    var src_size: int = _get_item_stack_size(item_src)
+    if src_size <= 0:
+        return
+
+    var dst_size: int = _get_item_stack_size(item_dst)
+    var dst_max_size: int = _get_item_max_stack_size(item_dst)
+    var free_dst_stack_space: int = dst_max_size - dst_size
+    if free_dst_stack_space <= 0:
+        return
+
+    _set_item_stack_size(item_dst, min(dst_size + src_size, dst_max_size))
+    _set_item_stack_size(item_src, max(src_size - free_dst_stack_space, 0))
 
 
 func transfer(item: InventoryItem, destination: Inventory) -> bool:
@@ -168,7 +200,7 @@ func split(item: InventoryItem, new_stack_size: int) -> InventoryItem:
     _set_item_stack_size(item, stack_size - new_stack_size)
     emit_signal("occupied_space_changed")
     _calculate_occupied_space()
-    assert(add_item(new_item))
+    assert(.add_item(new_item))
     return new_item
 
 
@@ -211,7 +243,7 @@ func transfer_autosplitmerge(item: InventoryItem, destination: Inventory) -> boo
     if destination.has_place_for(item):
         return transfer_automerge(item, destination)
 
-    var count: int = int(destination.get_free_space()) / int(_get_item_unit_weight(item))
+    var count: int = int(destination.get_free_space() / _get_item_unit_weight(item))
     if count > 0:
         var new_item: InventoryItem = split(item, count)
         assert(new_item != null)

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -24,6 +24,7 @@ Basic inventory class. Supports basic inventory operations (adding, removing, tr
 * `remove_item(item: InventoryItem) -> bool` - Removes the given item from the inventory.
 * `remove_all_items() -> bool` - Removes the all items from the inventory.
 * `get_item_by_id(prototype_id: String) -> InventoryItem` - Returns the first found item with the given prototype ID.
+* `get_items_by_id(prototype_id: String) -> Array` - Returns an array of items with the given prototype ID.
 * `has_item_by_id(prototype_id: String) -> bool` - Checks if the inventory contains an item with the given prototype ID.
 * `transfer(item: InventoryItem, destination: Inventory) -> bool` - Transfers the given item into the given inventory.
 * `clear() -> void` - Clears all items from the inventory.

--- a/docs/inventory_stacked.md
+++ b/docs/inventory_stacked.md
@@ -13,6 +13,7 @@ Inventory that has a limited item capacity in terms of weight.
 
 ## Methods
 
+* `add_item_automerge(item: InventoryItem) -> bool` - Adds the given item stack to the inventory, automatically merging with existing item stacks with the same prototype ID.
 * `has_unlimited_capacity() -> bool` - Checks if the inventory has unlimited capacity (i.e. capacity is 0.0).
 * `get_free_space() -> float` - Returns the free available space in the inventory.
 * `has_place_for(item: InventoryItem) -> bool` - Checks if the inventory has enough free space for the given item.

--- a/docs/json_item_prototype.md
+++ b/docs/json_item_prototype.md
@@ -25,6 +25,7 @@ An array of these `Item Prototype`s are utilized inside an [`Item Protoset (JSON
 * `name: string` - The name of the item as displayed inside controls.
 * `image: string` - A resource path to a texture to use as the item's image inside controls. Example: `"image": "res://assets/image.png"`
 * `stack_size: int` - Defines the default stack size of the item. Newly created items that use this prototype will have this stack size. Has the value of 1 if not defined.
+* `max_stack_size: int` - Defines the maximal stack size of the item. Has the value of 100 if not defined.
 * `weight: float` - Defines the unit weight of the item. Has the value of 1.0 if not defined. NOTE: The total weight of an item is defined as its unit weight multiplied by its stack size.
 * `width: int` - Defines the width of the item. Has the value of 1 if not defined.
 * `height: int` - Defines the height of the item. Has the value of 1 if not defined.

--- a/examples/inventory_stacked_transfer.tscn
+++ b/examples/inventory_stacked_transfer.tscn
@@ -122,6 +122,14 @@ script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "stackable_item"
 
+[node name="limited_stackable_item" type="Node" parent="InventoryStackedLeft"]
+script = ExtResource( 8 )
+protoset = ExtResource( 3 )
+prototype_id = "limited_stackable_item"
+properties = {
+"stack_size": 3.0
+}
+
 [node name="InventoryStackedRight" type="Node" parent="."]
 script = ExtResource( 2 )
 item_protoset = ExtResource( 3 )
@@ -141,6 +149,14 @@ prototype_id = "big_item"
 script = ExtResource( 8 )
 protoset = ExtResource( 3 )
 prototype_id = "stackable_item"
+
+[node name="limited_stackable_item" type="Node" parent="InventoryStackedRight"]
+script = ExtResource( 8 )
+protoset = ExtResource( 3 )
+prototype_id = "limited_stackable_item"
+properties = {
+"stack_size": 4.0
+}
 
 [node name="ItemSlot" type="Node" parent="."]
 script = ExtResource( 7 )

--- a/tests/data/item_definitions_stack.tres
+++ b/tests/data/item_definitions_stack.tres
@@ -11,11 +11,16 @@ json_data = "[
     {
         \"id\": \"big_item\",
         \"weight\": 20,
-		\"image\": \"res://images/item_book_blue.png\"
+        \"image\": \"res://images/item_book_blue.png\"
     },
     {
         \"id\": \"stackable_item\",
         \"stack_size\": 10,
-		\"image\": \"res://images/item_scroll_blue.png\"
+        \"image\": \"res://images/item_scroll_blue.png\"
+    },
+    {
+        \"id\": \"limited_stackable_item\",
+        \"max_stack_size\": 5,
+        \"stack_size\": 5
     }
 ]"

--- a/tests/inventory_stacked_tests.gd
+++ b/tests/inventory_stacked_tests.gd
@@ -42,6 +42,18 @@ func init_test() -> void:
     stackable_item.protoset = preload("res://tests/data/item_definitions_stack.tres")
     stackable_item.prototype_id = "stackable_item"
 
+    stackable_item_2 = InventoryItem.new()
+    stackable_item_2.protoset = preload("res://tests/data/item_definitions_stack.tres")
+    stackable_item_2.prototype_id = "stackable_item"
+
+    limited_stackable_item = InventoryItem.new()
+    limited_stackable_item.protoset = preload("res://tests/data/item_definitions_stack.tres")
+    limited_stackable_item.prototype_id = "limited_stackable_item"
+
+    limited_stackable_item_2 = InventoryItem.new()
+    limited_stackable_item_2.protoset = preload("res://tests/data/item_definitions_stack.tres")
+    limited_stackable_item_2.prototype_id = "limited_stackable_item"
+
 
 func cleanup_test() -> void:
     free_inventory(inventory)
@@ -49,6 +61,9 @@ func cleanup_test() -> void:
     free_item(item)
     free_item(big_item)
     free_item(stackable_item)
+    free_item(stackable_item_2)
+    free_item(limited_stackable_item)
+    free_item(limited_stackable_item_2)
 
 
 func test_space() -> void:

--- a/tests/inventory_stacked_tests.gd
+++ b/tests/inventory_stacked_tests.gd
@@ -137,6 +137,7 @@ func test_automerge() -> void:
 
 
 func test_max_stack_size() -> void:
+    limited_stackable_item.set_property(InventoryStacked.KEY_STACK_SIZE, 3)
     assert(inventory.add_item(limited_stackable_item))
     assert(limited_stackable_item.get_property(InventoryStacked.KEY_STACK_SIZE) == 3)
     assert(inventory.add_item(limited_stackable_item_2))

--- a/tests/inventory_stacked_tests.gd
+++ b/tests/inventory_stacked_tests.gd
@@ -4,6 +4,9 @@ var inventory: InventoryStacked
 var item: InventoryItem
 var big_item: InventoryItem
 var stackable_item: InventoryItem
+var stackable_item_2: InventoryItem
+var limited_stackable_item: InventoryItem
+var limited_stackable_item_2: InventoryItem
 
 
 func init_suite() -> void:
@@ -15,6 +18,8 @@ func init_suite() -> void:
         "test_invalid_capacity",
         "test_contents_changed_signal",
         "test_stack_split_join",
+        "test_automerge",
+        "test_max_stack_size",
         "test_serialize",
         "test_serialize_json"
     ]
@@ -104,6 +109,24 @@ func test_stack_split_join() -> void:
     assert(inventory.join(item1, item2))
     assert(item1.get_property(InventoryStacked.KEY_STACK_SIZE) == 10)
     assert(inventory.get_items().size() == 1)
+
+
+func test_automerge() -> void:
+    stackable_item.set_property(InventoryStacked.KEY_STACK_SIZE, 2)
+    stackable_item_2.set_property(InventoryStacked.KEY_STACK_SIZE, 2)
+    assert(inventory.add_item(stackable_item))
+    assert(inventory.get_items().size() == 1)
+    assert(is_instance_valid(stackable_item))
+    assert(inventory.add_item(stackable_item_2))
+    assert(inventory.get_items().size() == 1)
+
+
+func test_max_stack_size() -> void:
+    assert(inventory.add_item(limited_stackable_item))
+    assert(limited_stackable_item.get_property(InventoryStacked.KEY_STACK_SIZE) == 3)
+    assert(inventory.add_item(limited_stackable_item_2))
+    assert(limited_stackable_item.get_property(InventoryStacked.KEY_STACK_SIZE) == 5)
+    assert(limited_stackable_item_2.get_property(InventoryStacked.KEY_STACK_SIZE) == 3)
 
 
 func test_serialize() -> void:


### PR DESCRIPTION
Apart from `stack_size`, `InventoryStacked` items can now have a `max_stack_size` property that defines the maximal stack size. Item stacks exceeding the `max_stack_size` can be split up into multiple stacks.