### PR TITLE
[CtrlInventoryGrid] Fixing some clickthrough problems

### DIFF
--- a/addons/gloot/ctrl_inventory_grid.gd
+++ b/addons/gloot/ctrl_inventory_grid.gd
@@ -354,6 +354,11 @@ func _select(item: InventoryItem) -> void:
         emit_signal("item_deselected", prev_selected_item)
 
 
+# Using _input instead of _gui_input because _gui_input is only called for "mouse released"
+# (InputEventMouseButton.pressed==false) events if the same control previously triggered the "mouse
+# pressed" event (InputEventMouseButton.pressed==true).
+# This makes dragging items from one CtrlInventoryGrid to another impossible to implement with
+# _gui_input.
 func _input(event: InputEvent) -> void:
     if !(event is InputEventMouseButton):
         return

--- a/addons/gloot/ctrl_inventory_grid_ex.gd
+++ b/addons/gloot/ctrl_inventory_grid_ex.gd
@@ -100,6 +100,7 @@ func _create_selection_panel() -> void:
     move_child(_selection_panel, get_child_count() - 1)
     _set_panel_style(_selection_panel, selection_style)
     _selection_panel.visible = (_selected_item != null) && (selection_style != null)
+    _selection_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
     _selection_panel.connect("mouse_entered", Callable(self, "_on_selection_mouse_entered"))
     _selection_panel.connect("mouse_exited", Callable(self, "_on_selection_mouse_exited"))
 

--- a/addons/gloot/ctrl_inventory_item_rect.gd
+++ b/addons/gloot/ctrl_inventory_item_rect.gd
@@ -91,7 +91,7 @@ func _draw() -> void:
         draw_rect(rect, Color.WHITE, false)
 
 
-func _input(event: InputEvent) -> void:
+func _gui_input(event: InputEvent) -> void:
     if !(event is InputEventMouseButton):
         return
 


### PR DESCRIPTION
Some of the clickthrought problems are fixed by replacing `_input()` with `_gui_input()` at some places. That should prevent items from being grabbed when positioned behind other controls, while dropping them behind other controls is still possible.

Item drops are still an issue because `_gui_input()` is only called for "mouse released" (`InputEventMouseButton.pressed==false`) events if the same control previously triggered the "mouse pressed" event (`InputEventMouseButton.pressed==true`). This forces me to use `_input()` for item drops, which still has the problem of being detected "behind" other controls.