### PR TITLE
Remove annotation for texture path in ctrl_inventory_item_rect.

### DIFF
--- a/addons/gloot/ctrl_inventory_item_rect.gd
+++ b/addons/gloot/ctrl_inventory_item_rect.gd
@@ -12,7 +12,7 @@ var item: InventoryItem :
     set(new_item):
         item = new_item
         if item && ctrl_inventory:
-            var texture_path: String = item.get_property(CtrlInventory.KEY_IMAGE)
+            var texture_path = item.get_property(CtrlInventory.KEY_IMAGE)
             if texture_path:
                 texture = load(texture_path)
             _refresh()


### PR DESCRIPTION
![image](https://github.com/peter-kish/gloot/assets/49783296/917a3681-f68b-49c1-b871-66bab380314f)

I get crashes because my texture_path is null in ctrl_inventory_item_rect. removing the annotation fixes my issues. I don't think GDScript has union types :shrug: . Maybe could do String or null/Nil somehow. I propose just removing the annotation make it less fickle.

![image](https://github.com/peter-kish/gloot/assets/49783296/2f4c8064-a5e6-4a3b-a134-161853dee087).

I have a default image selected in CtrlInventoryGrid, I don't have image set on the InventoryItem though; probably why it is null? (Like it seems to work fine?).  Or Is it that the other slots aren't filled in with an image (unlikely)?

So if I remove the default image and try and drag:
![image](https://github.com/peter-kish/gloot/assets/49783296/b781b51f-ac01-43ac-9718-80af47cee1cb)

So maybe the logic should be if a default item texture  has been picked then texture_path can be null instead of a string :thinking:  (I probably should of opened this as an issue instead..., too lazy now)

