### PR TITLE
Fixing Protoset Editor

### DIFF
--- a/addons/gloot/editor/protoset_editor/protoset_editor.gd
+++ b/addons/gloot/editor/protoset_editor/protoset_editor.gd
@@ -126,7 +126,7 @@ func _on_property_removed(property_name: String) -> void:
     GlootUndoRedo.set_prototype_properties(protoset, selected_prototype_id, new_properties)
 
 
-func _on_prototype_id_changed() -> void:
+func _on_prototype_id_changed(_prototype_id: String) -> void:
     _refresh_btn_add_prototype()
     _refresh_btn_rename_prototype()
 


### PR DESCRIPTION
Screenshot of the bug: 
![image](https://github.com/peter-kish/gloot/assets/29582336/1b2403db-cfc5-4fa9-8ecf-25168f500bbf)


This bug wasn't enabling the add button even when the prototype_id was filled

Fixing the signal because now the signal needs at least one parameter.