### PR TITLE
Fix places where I'm getting crashes.

### DIFF
--- a/addons/gloot/ui/ctrl_dragable.gd
+++ b/addons/gloot/ui/ctrl_dragable.gd
@@ -89,7 +89,7 @@ func drag_end() -> void:
     drag_preview.mouse_filter = Control.MOUSE_FILTER_PASS
 
 
-func _process(_delta) -> void:
+func _physics_process(_delta:float) -> void:
     if drag_preview:
         drag_preview.global_position = get_global_mouse_position() - get_grab_offset()
 

--- a/addons/gloot/ui/ctrl_inventory_grid_ex.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid_ex.gd
@@ -67,7 +67,7 @@ func _refresh_selection() -> void:
 
 
 func _refresh_field_background_grid() -> void:
-    if _field_background_grid !=null:
+    if _field_background_grid != null:
         remove_child(_field_background_grid)
         _field_background_grid.queue_free()
         _field_background_grid = null

--- a/addons/gloot/ui/ctrl_inventory_grid_ex.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid_ex.gd
@@ -67,7 +67,7 @@ func _refresh_selection() -> void:
 
 
 func _refresh_field_background_grid() -> void:
-    if _field_background_grid:
+    if _field_background_grid !=null:
         remove_child(_field_background_grid)
         _field_background_grid.queue_free()
         _field_background_grid = null

--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -228,6 +228,6 @@ func _refresh() -> void:
 func _clear() -> void:
     if _label != null:
         _label.text = ""
-    if _ctrl_inventory_item_rect !=null:
+    if _ctrl_inventory_item_rect != null:
         _ctrl_inventory_item_rect.item = null
 

--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -226,8 +226,8 @@ func _refresh() -> void:
 
 
 func _clear() -> void:
-    if _label:
+    if _label != null:
         _label.text = ""
-    if _ctrl_inventory_item_rect:
+    if _ctrl_inventory_item_rect !=null:
         _ctrl_inventory_item_rect.item = null
 


### PR DESCRIPTION
I added checks for null in some places where I was getting crashes from freeing stuff that doesn't exist.

Keep in mind some of these crashes happen when switching scenes, so that might be why I'm encountering some of these errors.

I also changed to physics_process which runs at a constant rate (60 by default) rather than as fast as your CPU can tick if you have v sync off which for me costs around 0.3 ms. I guess you could also get an unfair advantage in multiplayer games :thinking: 