### PR TITLE
Added doc comments to generate in-engine help docs

### DIFF
--- a/addons/gloot/core/inventory_grid.gd
+++ b/addons/gloot/core/inventory_grid.gd
@@ -3,10 +3,16 @@
 extends Inventory
 class_name InventoryGrid
 
+## Inventory that has a limited capacity in terms of space.
+##
+## The inventory capacity is defined by its width and height.
+
+## Emitted when the size of the inventory has changed.
 signal size_changed
 
 const DEFAULT_SIZE: Vector2i = Vector2i(10, 10)
 
+## The size of the inventory (width and height).
 @export var size: Vector2i = DEFAULT_SIZE :
     get:
         if _constraint_manager == null:
@@ -23,51 +29,69 @@ func _init() -> void:
     _constraint_manager.enable_grid_constraint()
     _constraint_manager.get_grid_constraint().size_changed.connect(func(): size_changed.emit())
 
-
+## Returns the position of the given item in the inventory.
 func get_item_position(item: InventoryItem) -> Vector2i:
     return _constraint_manager.get_grid_constraint().get_item_position(item)
 
-
+## Returns the size of the given item.
 func get_item_size(item: InventoryItem) -> Vector2i:
     return _constraint_manager.get_grid_constraint().get_item_size(item)
 
-
+## Returns the position and size of the given item in the inventory.
 func get_item_rect(item: InventoryItem) -> Rect2i:
     return _constraint_manager.get_grid_constraint().get_item_rect(item)
 
-
+## Sets the item rotation (indicated by the [code]rotation[/code] property).
+##
+## Items can be rotated by positive or negative 90 degrees (indicated by the
+## [code]positive_rotation[/code] property).
+##
+## Returns [code]false[/code] if the rotation can't be performed, i.e. the item
+## is already rotated or the rotation is obstructed by other items/inventory
+## boundaries.
 func set_item_rotation(item: InventoryItem, rotated: bool) -> bool:
     return _constraint_manager.get_grid_constraint().set_item_rotation(item, rotated)
 
-
+## Toggles item rotation. Returns [code]false[/code] if the rotation can't be
+## performed, i.e. the item is already rotated or the rotation is obstructed
+## by other items/inventory boundaries.
 func rotate_item(item: InventoryItem) -> bool:
     return _constraint_manager.get_grid_constraint().rotate_item(item)
 
-
+## Checks if the item is rotated (indicated by the [code]rotated[/code]
+## property).
 func is_item_rotated(item: InventoryItem) -> bool:
     return _constraint_manager.get_grid_constraint().is_item_rotated(item)
 
-
+## Checks if there's place for the item to be rotated.
 func can_rotate_item(item: InventoryItem) -> bool:
     return _constraint_manager.get_grid_constraint().can_rotate_item(item)
 
-
+## Sets the item rotation to positive or negative (indicated by the
+## [code]positive_rotation[/code] property).
+## This does not affect the resulting size of the rotated item, only the
+## way it is rendered in the UI. If the item seems to be rendered upside-down
+## after a rotation, set the rotation direction to negative.
 func set_item_rotation_direction(item: InventoryItem, positive: bool) -> void:
     _constraint_manager.set_item_rotation_direction(item, positive)
 
-
+## Checks if the item rotation is positive (indicated by the
+## [code]positive_rotation[/code]).
 func is_item_rotation_positive(item: InventoryItem) -> bool:
     return _constraint_manager.get_grid_constraint().is_item_rotation_positive(item)
 
-
+## Adds the given item to the inventory, at the given position.
 func add_item_at(item: InventoryItem, position: Vector2i) -> bool:
     return _constraint_manager.get_grid_constraint().add_item_at(item, position)
 
-
+## Creates an [InventoryItem] based on the given prototype ID and adds it
+## to the inventory at the given position. Returns [code]null[/code] if the
+## item cannot be added.
 func create_and_add_item_at(prototype_id: String, position: Vector2i) -> InventoryItem:
     return _constraint_manager.get_grid_constraint().create_and_add_item_at(prototype_id, position)
 
-
+## Returns the item at the given position in the inventory. Returns
+## [code]null[/code] if the given field is empty.
 func get_item_at(position: Vector2i) -> InventoryItem:
     return _constraint_manager.get_grid_constraint().get_item_at(position)
 
@@ -75,23 +99,27 @@ func get_item_at(position: Vector2i) -> InventoryItem:
 func get_items_under(rect: Rect2i) -> Array[InventoryItem]:
     return _constraint_manager.get_grid_constraint().get_items_under(rect)
 
-
+## Moves the given item in the inventory to the new given position.
 func move_item_to(item: InventoryItem, position: Vector2i) -> bool:
     return _constraint_manager.get_grid_constraint().move_item_to(item, position)
 
-
+## Transfers the given item to the given inventory to the given inventory position.
 func transfer_to(item: InventoryItem, destination: Inventory, position: Vector2i) -> bool:
     return _constraint_manager.get_grid_constraint().transfer_to(item, destination._constraint_manager.get_grid_constraint(), position)
 
-
+## Checks if the given rectangle is not occupied by any items (with a given
+## optional exception).
 func rect_free(rect: Rect2i, exception: InventoryItem = null) -> bool:
     return _constraint_manager.get_grid_constraint().rect_free(rect, exception)
 
-
+## Finds a free place for the given item. Returns a dictionary with two fields:
+## [code]success[/code] and [code]position[/code]. If [code]success[/code] is
+## true a free place has been found and is stored in the [code]position[/code]
+## field. Otherwise [code]success[/code] is set to false.
 func find_free_place(item: InventoryItem) -> Dictionary:
     return _constraint_manager.get_grid_constraint().find_free_place(item)
 
-
+## Sorts the inventory items by size.
 func sort() -> bool:
     return _constraint_manager.get_grid_constraint().sort()
 

--- a/addons/gloot/core/inventory_grid_stacked.gd
+++ b/addons/gloot/core/inventory_grid_stacked.gd
@@ -3,6 +3,8 @@
 extends InventoryGrid
 class_name InventoryGridStacked
 
+## Grid based inventory that supports item stacks.
+
 const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_constraint.gd")
 
 
@@ -10,55 +12,63 @@ func _init() -> void:
     super._init()
     _constraint_manager.enable_stacks_constraint()
 
-
+## Checks if the inventory has enough free space for the given item.
 func has_place_for(item: InventoryItem) -> bool:
     return _constraint_manager.has_space_for(item)
 
-
+## Adds the given item stack to the inventory, automatically merging the
+## existing item stacks with the same property ID.
 func add_item_automerge(item: InventoryItem) -> bool:
     return _constraint_manager.get_stacks_constraint().add_item_automerge(item)
-    
-    
+
+## Splits the given item stack into two. The newly created stack will have the
+## size [param new_stack_size], while the old stack will contain the remainder.
 func split(item: InventoryItem, new_stack_size: int) -> InventoryItem:
     return _constraint_manager.get_stacks_constraint().split_stack_safe(item, new_stack_size)
 
-
+## Joins the [param item_src] item stack with the [param item_dst] stack.
 func join(item_dst: InventoryItem, item_src: InventoryItem) -> bool:
     return _constraint_manager.get_stacks_constraint().join_stacks(item_dst, item_src)
 
-
+## Returns the stack size of the given item.
 static func get_item_stack_size(item: InventoryItem) -> int:
     return StacksConstraint.get_item_stack_size(item)
 
-
+## Sets the stack size of the given item.
+## If the stack size is set to 0 the item will be removed from its directory
+## and queued for deletion. If [param new_stack_size] is greater than the
+## maximum stack size or negative, the stack size will remained unchanged
+## and the function will return [code]false[/code].
 static func set_item_stack_size(item: InventoryItem, new_stack_size: int) -> bool:
     return StacksConstraint.set_item_stack_size(item, new_stack_size)
 
-
+## Returns the maximum stack size for the given item.
 static func get_item_max_stack_size(item: InventoryItem) -> int:
     return StacksConstraint.get_item_max_stack_size(item)
 
-
+## Sets the maximum stack size for the given item.
 static func set_item_max_stack_size(item: InventoryItem, new_stack_size: int) -> void:
     StacksConstraint.set_item_max_stack_size(item, new_stack_size)
 
-
+## Returns the stack size of the given item prototype.
 func get_prototype_stack_size(prototype_id: String) -> int:
     return _constraint_manager.get_stacks_constraint().get_prototype_stack_size(item_protoset, prototype_id)
 
-
+## Returns the maximum stack size of the given item prototype.
 func get_prototype_max_stack_size(prototype_id: String) -> int:
     return _constraint_manager.get_stacks_constraint().get_prototype_max_stack_size(item_protoset, prototype_id)
 
-
+## Transfers the given item stack into the given inventory, joining it with any available item
+## stacks with the same prototype ID.
 func transfer_automerge(item: InventoryItem, destination: Inventory) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_automerge(item, destination)
 
-
+## Transfers the given item stack into the given inventory, splitting it up
+## and joining it with available item stacks, as needed.
 func transfer_autosplitmerge(item: InventoryItem, destination: Inventory) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_autosplitmerge(item, destination)
 
-
+## Merges the given item with all compatible items in the same inventory.
 static func pack(item: InventoryItem) -> void:
     return StacksConstraint.pack_item(item)
 

--- a/addons/gloot/core/inventory_stacked.gd
+++ b/addons/gloot/core/inventory_stacked.gd
@@ -3,11 +3,17 @@
 extends Inventory
 class_name InventoryStacked
 
+## Inventory that has a limited item capacity in terms of weight.
+
 const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_constraint.gd")
 
+## Emitted when the inventory capacity has changed.
 signal capacity_changed
+## Emitted when the amount of occupied space in the inventory has changed.
 signal occupied_space_changed
 
+## Maximum weight the inventory can hold.
+## Set to 0.0 for unlimited capacity.
 @export var capacity: float :
     get:
         if _constraint_manager == null:
@@ -17,6 +23,8 @@ signal occupied_space_changed
         return _constraint_manager.get_weight_constraint().capacity
     set(new_capacity):
         _constraint_manager.get_weight_constraint().capacity = new_capacity
+
+## Currently occupied space in the inventory
 var occupied_space: float :
     get:
         if _constraint_manager == null:
@@ -35,66 +43,77 @@ func _init() -> void:
     _constraint_manager.get_weight_constraint().capacity_changed.connect(func(): capacity_changed.emit())
     _constraint_manager.get_weight_constraint().occupied_space_changed.connect(func(): occupied_space_changed.emit())
 
-
+## Checks if the inventory has unlimited capacity (i.e. capacity is 0.0).
 func has_unlimited_capacity() -> bool:
     return _constraint_manager.get_weight_constraint().has_unlimited_capacity()
 
-
+## Returns the free available space in the inventory.
 func get_free_space() -> float:
     return _constraint_manager.get_weight_constraint().get_free_space()
 
-
+## Checks if the inventory has enough free space for the given item.
 func has_place_for(item: InventoryItem) -> bool:
     return _constraint_manager.has_space_for(item)
 
-
+## Adds the given item stack to the inventory, automatically merging with
+## existing item stacks with the same prototype ID.
 func add_item_automerge(item: InventoryItem) -> bool:
     return _constraint_manager.get_stacks_constraint().add_item_automerge(item)
 
-
+## Splits the given item stack into two. The newly created stack will have
+## the size [param new_stack_size], while the old stack will contain
+## the remainder.
 func split(item: InventoryItem, new_stack_size: int) -> InventoryItem:
     return _constraint_manager.get_stacks_constraint().split_stack_safe(item, new_stack_size)
 
-
+## Joins the [param item_src] item stack with the [param item_dst] stack.
 static func join(item_dst: InventoryItem, item_src: InventoryItem) -> bool:
     return StacksConstraint.join_stacks(item_dst, item_src)
 
-
+## Returns the stack size of the given item.
 static func get_item_stack_size(item: InventoryItem) -> int:
     return StacksConstraint.get_item_stack_size(item)
 
-
+## Sets the stack size of the given item. If the stack size is set to 0 the item
+## will be removed from its directory and queued for deletion. If
+## [param new_stack_size] is greater than the maximum stack size or negative,
+## the stack size will remain unchanged and the function will return
+## [code]false[/code].
 static func set_item_stack_size(item: InventoryItem, new_stack_size: int) -> bool:
     return StacksConstraint.set_item_stack_size(item, new_stack_size)
 
-
+## Returns the maximum stack size for the given item.
 static func get_item_max_stack_size(item: InventoryItem) -> int:
     return StacksConstraint.get_item_max_stack_size(item)
 
-
+## Sets the maximum stack size for the given item.
 static func set_item_max_stack_size(item: InventoryItem, new_stack_size: int) -> void:
     StacksConstraint.set_item_max_stack_size(item, new_stack_size)
 
-
+## Returns the stack size of the given item prototype.
 func get_prototype_stack_size(prototype_id: String) -> int:
     return StacksConstraint.get_prototype_stack_size(item_protoset, prototype_id)
 
-
+## Returns the maximum stack size of the given item prototype.
 func get_prototype_max_stack_size(prototype_id: String) -> int:
     return StacksConstraint.get_prototype_max_stack_size(item_protoset, prototype_id)
 
-
+## Transfers the given item stack into the given inventory, splitting it if
+## there is not enough space for the whole stack.
 func transfer_autosplit(item: InventoryItem, destination: InventoryStacked) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_autosplit(item, destination) != null
 
-
+## Transfers the given item stack into the given inventory, joining it with any
+## available item stacks with the same prototype ID.
 func transfer_automerge(item: InventoryItem, destination: InventoryStacked) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_automerge(item, destination)
 
-
+## A combination of [method transfer_autosplit] and [method transfer_automerge].
+## Transfers the given item stack into the given inventory, splitting it up and
+## joining it with available item stacks, as needed.
 func transfer_autosplitmerge(item: InventoryItem, destination: InventoryStacked) -> bool:
     return _constraint_manager.get_stacks_constraint().transfer_autosplitmerge(item, destination)
 
-
+## Merges the given item with all compatible items in the same inventory.
 static func pack(item: InventoryItem) -> void:
     return StacksConstraint.pack_item(item)

--- a/addons/gloot/core/item_protoset.gd
+++ b/addons/gloot/core/item_protoset.gd
@@ -3,10 +3,13 @@
 class_name ItemProtoset
 extends Resource
 
+## A resource type holding a set of inventory item prototypes in JSON format.
+
 const Utils = preload("res://addons/gloot/core/utils.gd")
 
 const KEY_ID: String = "id"
 
+## JSON string containing item prototypes.
 @export_multiline var json_data: String :
     set(new_json_data):
         json_data = new_json_data
@@ -20,7 +23,8 @@ var _prototypes: Dictionary = {} :
         _update_json_data()
         _save()
 
-
+## Parses the given json string and generates a new [code]prototypes[/code]
+## dictionary.
 func parse(json: String) -> void:
     _prototypes.clear()
 
@@ -89,26 +93,26 @@ func _save() -> void:
     if !resource_path.is_empty():
         ResourceSaver.save(self)
 
-
+## Returns the prototype with the given ID.
 func get_prototype(id: StringName) -> Variant:
     assert(has_prototype(id), "No prototype with ID: %s" % id)
     return _prototypes[id]
 
-
+## Adds a prototype with the given ID.
 func add_prototype(id: String) -> void:
     assert(!has_prototype(id), "Prototype with ID already exists")
     _prototypes[id] = {KEY_ID: id}
     _update_json_data()
     _save()
 
-
+## Removes the prototype with the given ID.
 func remove_prototype(id: String) -> void:
     assert(has_prototype(id), "No prototype with ID: %s" % id)
     _prototypes.erase(id)
     _update_json_data()
     _save()
 
-
+## Duplicates the prototype with the given ID.
 func duplicate_prototype(id: String) -> void:
     assert(has_prototype(id), "No prototype with ID: %s" % id)
     var new_id = "%s_duplicate" % id
@@ -118,7 +122,7 @@ func duplicate_prototype(id: String) -> void:
     _update_json_data()
     _save()
 
-
+## Renames the prototype with the given ID to a new ID.
 func rename_prototype(id: String, new_id: String) -> void:
     assert(has_prototype(id), "No prototype with ID: %s" % id)
     assert(!has_prototype(new_id), "Prototype with ID already exists")
@@ -129,23 +133,25 @@ func rename_prototype(id: String, new_id: String) -> void:
     _update_json_data()
     _save()
 
-
 func set_prototype_properties(id: String, new_properties: Dictionary) -> void:
     _prototypes[id] = new_properties
     _update_json_data()
     _save()
 
-
+## Checks if a prototype with the given ID exists.
 func has_prototype(id: String) -> bool:
     return _prototypes.has(id)
 
-
+## Sets the property with the given value for the prototype with the
+## given ID.
 func set_prototype_property(id: String, property_name: String, value) -> void:
     assert(has_prototype(id), "No prototype with ID: %s" % id)
     var prototype = get_prototype(id)
     prototype[property_name] = value
 
-
+## Returns the value of the property with the given name from the prototype
+## with the given ID. In case the value can not be found, the default value
+## is returned.
 func get_prototype_property(id: String, property_name: String, default_value = null) -> Variant:
     if has_prototype(id):
         var prototype = get_prototype(id)
@@ -154,7 +160,7 @@ func get_prototype_property(id: String, property_name: String, default_value = n
     
     return default_value
 
-
+## Checks if the given prototype has the given property.
 func prototype_has_property(id: String, property_name: String) -> bool:
     if has_prototype(id):
         return get_prototype(id).has(property_name)

--- a/addons/gloot/core/item_ref_slot.gd
+++ b/addons/gloot/core/item_ref_slot.gd
@@ -3,12 +3,15 @@
 class_name ItemRefSlot
 extends "res://addons/gloot/core/item_slot_base.gd"
 
+## Holds a reference to an inventory item.
+
 signal inventory_changed
 
 const Verify = preload("res://addons/gloot/core/verify.gd")
 const KEY_ITEM_INDEX: String = "item_index"
 const EMPTY_SLOT = -1
 
+## Path to an [Inventory] node. Sets the [member inventory] property.
 @export var inventory_path: NodePath :
     set(new_inv_path):
         if inventory_path == new_inv_path:
@@ -20,6 +23,7 @@ const EMPTY_SLOT = -1
 var _wr_item: WeakRef = weakref(null)
 var _wr_inventory: WeakRef = weakref(null)
 @export var _equipped_item: int = EMPTY_SLOT : set = _set_equipped_item_index
+## Reference to an [Inventory] node.
 var inventory: Inventory = null :
     get = _get_inventory, set = _set_inventory
 
@@ -97,7 +101,10 @@ func _on_item_removed(item: InventoryItem) -> void:
 func _get_inventory() -> Inventory:
     return _wr_inventory.get_ref()
 
-
+## Equips the given inventory item in the slot. If the slot already holds an
+## item, [method clear] will be called first. Returns [code]false[/code] if the
+## [method clear] call fails, the slot can't hold the given item, or already
+## holds the given item. Returns [code]true[/code] otherwise.
 func equip(item: InventoryItem) -> bool:
     if !can_hold_item(item):
         return false
@@ -123,7 +130,7 @@ func equip_by_index(index: int) -> bool:
         return false
     return equip(_get_inventory().get_items()[index])
 
-
+## Clears the item slot.
 func clear() -> bool:
     if get_item() == null:
         return false
@@ -133,11 +140,13 @@ func clear() -> bool:
     cleared.emit()
     return true
 
-
+## Returns the equipped item.
 func get_item() -> InventoryItem:
     return _wr_item.get_ref()
 
-
+## Checks if the slot can hold the given item, i.e. [member inventory] contains
+## the given item and the item is not [code]null[/code]. This method can
+## be overriden to implement item slots that can only hold specific items.
 func can_hold_item(item: InventoryItem) -> bool:
     if item == null:
         return false
@@ -147,11 +156,11 @@ func can_hold_item(item: InventoryItem) -> bool:
 
     return true
 
-
+## Clears the item slot.
 func reset() -> void:
     clear()
 
-
+## Serializes the item slot into a dictionary.
 func serialize() -> Dictionary:
     var result: Dictionary = {}
     var item : InventoryItem = _wr_item.get_ref()
@@ -161,7 +170,10 @@ func serialize() -> Dictionary:
 
     return result
 
-
+## Loads the item slot data from the given dictionary.
+## [br]
+## [b]Note:[/b] [param inventory] must be set prior to the
+## [method deserialize] call!
 func deserialize(source: Dictionary) -> bool:
     if !Verify.dict(source, false, KEY_ITEM_INDEX, [TYPE_INT, TYPE_FLOAT]):
         return false

--- a/addons/gloot/core/item_slot_base.gd
+++ b/addons/gloot/core/item_slot_base.gd
@@ -3,40 +3,51 @@
 class_name ItemSlotBase
 extends Node
 
+## Base class for [ItemSlot] and [ItemRefSlot]
+
+## Emitted when an item is placed in the slot.
 signal item_equipped
+## Emitted when the slot is cleared.
 signal cleared
 
 
-# Override this
+## Equips the given inventory item in the slot. See the documentation
+## for [ItemSlot] and [ItemRefSlot] for more details.
 func equip(item: InventoryItem) -> bool:
     return false
 
 
-# Override this
+## Clears the item slot. See the documentation for [ItemSlot] and [ItemRefSlot]
+## for more details.
 func clear() -> bool:
     return false
 
 
-# Override this
+## Returns the equipped item. See the documentation for [ItemSlot] and
+## [ItemRefSlot] for more details.
 func get_item() -> InventoryItem:
     return null
 
 
-# Override this
+## Checks if the slot can hold the given item. See the documentation for [ItemSlot]
+## and [ItemRefSlot] for more details.
 func can_hold_item(item: InventoryItem) -> bool:
     return false
 
 
-# Override this
+## Clears the item slot. See the documentation for [ItemSlot] and [ItemRefSlot]
+## for more details.
 func reset() -> void:
     pass
 
 
-# Override this
+## Serializes the item slot into a dictionary. See the documentation for
+## [ItemSlot] and [ItemRefSlot] for more details.
 func serialize() -> Dictionary:
     return {}
 
 
-# Override this
+## Loads the item slot data from the given dictionary. See the documentation
+## for [ItemSlot] and [ItemRefSlot] for more details.
 func deserialize(source: Dictionary) -> bool:
     return false

--- a/addons/gloot/ui/ctrl_inventory.gd
+++ b/addons/gloot/ui/ctrl_inventory.gd
@@ -3,11 +3,18 @@
 class_name CtrlInventory
 extends Control
 
+## A UI control representing a basic [Inventory].
+##
+## Displays a list of items in the inventory.
+
+## Emitted when an [InventoryItem] is activated (i.e. double clicked).
 signal inventory_item_activated(item)
+## Emitted when the context menu of an [InventoryItem] is activated (i.e. right clicked).
 signal inventory_item_context_activated(item)
 
 enum SelectMode {SELECT_SINGLE = ItemList.SELECT_SINGLE, SELECT_MULTI = ItemList.SELECT_MULTI}
 
+## Path to an [Inventory] node.
 @export var inventory_path: NodePath :
     set(new_inv_path):
         inventory_path = new_inv_path
@@ -22,8 +29,10 @@ enum SelectMode {SELECT_SINGLE = ItemList.SELECT_SINGLE, SELECT_MULTI = ItemList
         inventory = node
         update_configuration_warnings()
 
-
+## The default icon that will be used for items with no [code]image[/code] property.
 @export var default_item_icon: Texture2D
+
+## Single or multi select mode (hold CTRL to select multiple items).
 @export_enum("Single", "Multi") var select_mode: int = SelectMode.SELECT_SINGLE :
     set(new_select_mode):
         if select_mode == new_select_mode:
@@ -32,6 +41,8 @@ enum SelectMode {SELECT_SINGLE = ItemList.SELECT_SINGLE, SELECT_MULTI = ItemList
         if is_instance_valid(_item_list):
             _item_list.deselect_all();
             _item_list.select_mode = select_mode
+
+## The [Inventory] node linked to this control.
 var inventory: Inventory = null :
     set(new_inventory):
         if new_inventory == inventory:
@@ -160,14 +171,15 @@ func _get_item_title(item: InventoryItem) -> String:
 
     return title
 
-
+## Returns the currently selected item. In case multiple items are selected,
+## the first one is returned.
 func get_selected_inventory_item() -> InventoryItem:
     if _item_list.get_selected_items().is_empty():
         return null
 
     return _get_inventory_item(_item_list.get_selected_items()[0])
 
-
+## Returns all the currently selected items.
 func get_selected_inventory_items() -> Array[InventoryItem]:
     var result: Array[InventoryItem]
     var indexes = _item_list.get_selected_items()
@@ -182,11 +194,11 @@ func _get_inventory_item(index: int) -> InventoryItem:
 
     return _item_list.get_item_metadata(index)
 
-
+## Deselects the selected item.
 func deselect_inventory_item() -> void:
     _item_list.deselect_all()
 
-
+## Selects the given item.
 func select_inventory_item(item: InventoryItem) -> void:
     _item_list.deselect_all()
     for index in _item_list.item_count:

--- a/addons/gloot/ui/ctrl_inventory_grid.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid.gd
@@ -3,11 +3,27 @@
 class_name CtrlInventoryGrid
 extends Control
 
+## A UI control representing a grid-based inventory ([InventoryGrid]).
+##
+## Displays a grid based on the inventory capacity (width and height) and the
+## contained items on the grid. The items can be moved around in the inventory
+## by dragging.
+
+## Emitted when a grabbed [InventoryItem] is dropped.
 signal item_dropped(item, offset)
+## Emitted when the selection has changed. Use [method get_selected_inventory_item]
+## to obtain the currently selected item.
 signal selection_changed
+## Emitted when an [InventoryItem] is activated (i.e. double clicked).
 signal inventory_item_activated(item)
+## Emitted when the context menu of an [InventoryItem] is activated
+## (i.e. right clicked).
 signal inventory_item_context_activated(item)
+## Emitted when the mouse enters the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_entered(item)
+## Emitted when the mouse leaves the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_exited(item)
 
 const CtrlInventoryGridBasic = preload("res://addons/gloot/ui/ctrl_inventory_grid_basic.gd")
@@ -47,6 +63,7 @@ class GridControl extends Control:
             draw_line(from, to, color)
         
 
+## Path to an [Inventory] node.
 @export var inventory_path: NodePath :
     set(new_inv_path):
         if new_inv_path == inventory_path:
@@ -62,50 +79,70 @@ class GridControl extends Control:
             
         inventory = node
         update_configuration_warnings()
+
+## The default texture that will be used for items with no [code]image[/code]
+## property.
 @export var default_item_texture: Texture2D :
     set(new_default_item_texture):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.default_item_texture = new_default_item_texture
         default_item_texture = new_default_item_texture
+
+## If true, the inventory item sprites will be stretched to fit the inventory
+## fields they are positioned on.
 @export var stretch_item_sprites: bool = true :
     set(new_stretch_item_sprites):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.stretch_item_sprites = new_stretch_item_sprites
         stretch_item_sprites = new_stretch_item_sprites
+
+## The size of each inventory field in pixels.
 @export var field_dimensions: Vector2 = Vector2(32, 32) :
     set(new_field_dimensions):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.field_dimensions = new_field_dimensions
         field_dimensions = new_field_dimensions
+
+## The spacing between items in pixels.
 @export var item_spacing: int = 0 :
     set(new_item_spacing):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.item_spacing = new_item_spacing
         item_spacing = new_item_spacing
+
+## Displays a grid if true.
 @export var draw_grid: bool = true :
     set(new_draw_grid):
         if new_draw_grid == draw_grid:
             return
         draw_grid = new_draw_grid
         _queue_refresh()
+
+## The color of the grid.
 @export var grid_color: Color = Color.BLACK :
     set(new_grid_color):
         if(new_grid_color == grid_color):
             return
         grid_color = new_grid_color
         _queue_refresh()
+
+## Draws a rectangle behind the selected item if true.
 @export var draw_selections: bool = false :
     set(new_draw_selections):
         if new_draw_selections == draw_selections:
             return
         draw_selections = new_draw_selections
         _queue_refresh()
+
+## The color of the selection.
 @export var selection_color: Color = Color.GRAY :
     set(new_selection_color):
         if(new_selection_color == selection_color):
             return
         selection_color = new_selection_color
         _queue_refresh()
+
+## Single or multi select mode (hold CTRL to select multiple items).
 @export_enum("Single", "Multi") var select_mode: int = CtrlInventoryGridBasic.SelectMode.SELECT_SINGLE :
     set(new_select_mode):
         if select_mode == new_select_mode:
@@ -114,6 +151,7 @@ class GridControl extends Control:
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.select_mode = select_mode
 
+## The [InventoryGrid] node linked to this control.
 var inventory: InventoryGrid = null :
     set(new_inventory):
         if inventory == new_inventory:
@@ -268,25 +306,26 @@ func _get_inventory() -> InventoryGrid:
         return null
     return _ctrl_inventory_grid_basic.inventory
 
-
+## Deselects the selected item.
 func deselect_inventory_item() -> void:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return
     _ctrl_inventory_grid_basic.deselect_inventory_item()
 
-
+## Selects the given item.
 func select_inventory_item(item: InventoryItem) -> void:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return
     _ctrl_inventory_grid_basic.select_inventory_item(item)
 
-
+## Returns the currently selected item. In case multiple items are selected,
+## the first one is returned.
 func get_selected_inventory_item() -> InventoryItem:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return null
     return _ctrl_inventory_grid_basic.get_selected_inventory_item()
 
-
+## Returns all the currently selected items.
 func get_selected_inventory_items() -> Array[InventoryItem]:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return []

--- a/addons/gloot/ui/ctrl_inventory_grid_ex.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid_ex.gd
@@ -3,11 +3,24 @@
 class_name CtrlInventoryGridEx
 extends Control
 
+## A UI control similar to [CtrlInventoryGrid] but with extended options for
+## customization.
+
+## Emitted when a grabbed [InventoryItem] is dropped.
 signal item_dropped(item, offset)
+## Emitted when the selection has changed. Use [method get_selected_inventory_item]
+## to obtain the currently selected item.
 signal selection_changed
+## Emitted when an [InventoryItem] is activated (i.e. double clicked).
 signal inventory_item_activated(item)
+## Emitted when the context menu of an [InventoryItem] is activated
+## (i.e. right clicked).
 signal inventory_item_context_activated(item)
+## Emitted when the mouse enters the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_entered(item)
+## Emitted when the mouse leaves the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_exited(item)
 
 const Verify = preload("res://addons/gloot/core/verify.gd")
@@ -65,7 +78,7 @@ class SelectionPanel extends Panel:
         if style != null:
             add_theme_stylebox_override("panel", style)
 
-
+## Path to an [Inventory] node.
 @export var inventory_path: NodePath :
     set(new_inv_path):
         if new_inv_path == inventory_path:
@@ -81,26 +94,38 @@ class SelectionPanel extends Panel:
             
         inventory = node
         update_configuration_warnings()
+
+## The default texture that will be used for items with no [code]image[/code]
+## property.
 @export var default_item_texture: Texture2D :
     set(new_default_item_texture):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.default_item_texture = new_default_item_texture
         default_item_texture = new_default_item_texture
+
+## If true, the inventory item sprites will be stretched to fit the inventory
+## fields they are positioned on.
 @export var stretch_item_sprites: bool = true :
     set(new_stretch_item_sprites):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.stretch_item_sprites = new_stretch_item_sprites
         stretch_item_sprites = new_stretch_item_sprites
+
+## The size of each inventory field in pixels.
 @export var field_dimensions: Vector2 = Vector2(32, 32) :
     set(new_field_dimensions):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.field_dimensions = new_field_dimensions
         field_dimensions = new_field_dimensions
+
+## The spacing between items in pixels.
 @export var item_spacing: int = 0 :
     set(new_item_spacing):
         if is_instance_valid(_ctrl_inventory_grid_basic):
             _ctrl_inventory_grid_basic.item_spacing = new_item_spacing
         item_spacing = new_item_spacing
+
+## Single or multi select mode (hold CTRL to select multiple items).
 @export_enum("Single", "Multi") var select_mode: int = CtrlInventoryGridBasic.SelectMode.SELECT_SINGLE :
     set(new_select_mode):
         if select_mode == new_select_mode:
@@ -110,23 +135,31 @@ class SelectionPanel extends Panel:
             _ctrl_inventory_grid_basic.select_mode = select_mode
 
 @export_group("Custom Styles")
+## Style of a single inventory field.
 @export var field_style: StyleBox :
     set(new_field_style):
         field_style = new_field_style
         _queue_refresh()
+
+## Style of a single inventory field when the mouse hovers over it.
 @export var field_highlighted_style: StyleBox :
     set(new_field_highlighted_style):
         field_highlighted_style = new_field_highlighted_style
         _queue_refresh()
+
+## Style of a single inventory field when the item on top of it is selected.
 @export var field_selected_style: StyleBox :
     set(new_field_selected_style):
         field_selected_style = new_field_selected_style
         _queue_refresh()
+
+## Style of a rectangle that will be drawn on top of the selected item.
 @export var selection_style: StyleBox :
     set(new_selection_style):
         selection_style = new_selection_style
         _queue_refresh()
 
+## The [Inventory] node linked to this control.
 var inventory: InventoryGrid = null :
     set(new_inventory):
         if inventory == new_inventory:
@@ -382,25 +415,26 @@ func _get_global_grabbed_item_local_pos() -> Vector2:
         return get_local_mouse_position() - CtrlDragable.get_grab_offset_local_to(self)
     return Vector2(-1, -1)
 
-
+## Deselects the selected item.
 func deselect_inventory_item() -> void:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return
     _ctrl_inventory_grid_basic.deselect_inventory_item()
 
-
+## Selects the given item.
 func select_inventory_item(item: InventoryItem) -> void:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return
     _ctrl_inventory_grid_basic.select_inventory_item(item)
 
-
+## Returns the currently selected item. In case multiple items are selected,
+## the first one is returned.
 func get_selected_inventory_item() -> InventoryItem:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return null
     return _ctrl_inventory_grid_basic.get_selected_inventory_item()
 
-
+## Returns all the currently selected items.
 func get_selected_inventory_items() -> Array[InventoryItem]:
     if !is_instance_valid(_ctrl_inventory_grid_basic):
         return []

--- a/addons/gloot/ui/ctrl_inventory_stacked.gd
+++ b/addons/gloot/ui/ctrl_inventory_stacked.gd
@@ -3,11 +3,19 @@
 class_name CtrlInventoryStacked
 extends CtrlInventory
 
+## A UI control representing a stack based inventory ([InventoryStacked]).
+##
+## It lists the contained items and shows an optional progress bar displaying
+## the capacity and fullness of the inventory.
+
+## If true, a progress bar will be shown indicating inventory fullness.
 @export var progress_bar_visible: bool = true :
     set(new_progress_bar_visible):
         progress_bar_visible = new_progress_bar_visible
         if _progress_bar:
             _progress_bar.visible = progress_bar_visible
+
+## If true, a percentage label will be shown indicating inventory fullness.
 @export var label_visible: bool = true :
     set(new_label_visible):
         label_visible = new_label_visible

--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -3,14 +3,24 @@
 class_name CtrlItemSlot
 extends Control
 
+## A UI control representing an inventory slot ([ItemSlot]).
+##
+## Displays the texture of the set item and its name. If not item is set,
+## it displays the given default texture.
+
 const CtrlInventoryItemRect = preload("res://addons/gloot/ui/ctrl_inventory_item_rect.gd")
 const CtrlDropZone = preload("res://addons/gloot/ui/ctrl_drop_zone.gd")
 const CtrlDragable = preload("res://addons/gloot/ui/ctrl_dragable.gd")
 const StacksConstraint = preload("res://addons/gloot/core/constraints/stacks_constraint.gd")
 
+## Emitted when the mouse enters the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_entered
+## Emitted when the mouse leaves the [Rect2] area of the control representing
+## the given [InventoryItem].
 signal item_mouse_exited
 
+## Path to an [ItemSlot] node.
 @export var item_slot_path: NodePath :
     set(new_item_slot_path):
         if item_slot_path == new_item_slot_path:
@@ -28,12 +38,17 @@ signal item_mouse_exited
         item_slot = node
         _refresh()
         update_configuration_warnings()
+
+## The default icon that will be used for items with no [code]image[/code]
+## property.
 @export var default_item_icon: Texture2D :
     set(new_default_item_icon):
         if default_item_icon == new_default_item_icon:
             return
         default_item_icon = new_default_item_icon
         _refresh()
+
+## The item texture is displayed if set to true.
 @export var item_texture_visible: bool = true :
     set(new_item_texture_visible):
         if item_texture_visible == new_item_texture_visible:
@@ -41,6 +56,8 @@ signal item_mouse_exited
         item_texture_visible = new_item_texture_visible
         if is_instance_valid(_ctrl_inventory_item_rect):
             _ctrl_inventory_item_rect.visible = item_texture_visible
+
+## The item name label is displayed if set to true.
 @export var label_visible: bool = true :
     set(new_label_visible):
         if label_visible == new_label_visible:
@@ -48,6 +65,7 @@ signal item_mouse_exited
         label_visible = new_label_visible
         if is_instance_valid(_label):
             _label.visible = label_visible
+
 @export_group("Icon Behavior", "icon_")
 @export var icon_stretch_mode: TextureRect.StretchMode = TextureRect.StretchMode.STRETCH_KEEP_CENTERED :
     set(new_icon_stretch_mode):
@@ -85,6 +103,8 @@ signal item_mouse_exited
         label_clip_text = new_label_clip_text
         if is_instance_valid(_label):
             _label.clip_text = label_clip_text
+
+## The [ItemSlot] node linked to this control.
 var item_slot: ItemSlotBase :
     set(new_item_slot):
         if new_item_slot == item_slot:

--- a/addons/gloot/ui/ctrl_item_slot_ex.gd
+++ b/addons/gloot/ui/ctrl_item_slot_ex.gd
@@ -3,10 +3,16 @@
 class_name CtrlItemSlotEx
 extends CtrlItemSlot
 
+## A UI control similar to [CtrlItemSlot] but with extended options for
+## customization.
+
+## Style of the slot background.
 @export var slot_style: StyleBox :
     set(new_slot_style):
         slot_style = new_slot_style
         _refresh()
+
+## Style of the slot background when the mouse hovers over it.
 @export var slot_highlighted_style: StyleBox :
     set(new_slot_highlighted_style):
         slot_highlighted_style = new_slot_highlighted_style


### PR DESCRIPTION
This commit uses Godot's new [documentation comments](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_documentation_comments.html) feature to add in-engine documentation for the classes within Gloot. I transcribed all of the files found in `docs/` to their respective classes, with minimal edits or changes (which can be done in later commits). Having the documentation in-engine helps massively in iteration speed, as it not only can be quickly accessed through the help search, but also the documentation can link to other classes, methods and members when they are referenced.

![image](https://github.com/peter-kish/gloot/assets/4079184/2127ecdc-ce48-42c0-bc88-2f3e90c02e3e)
![image](https://github.com/peter-kish/gloot/assets/4079184/26e560a7-e259-42e3-9eeb-baeef9d56a13)
