### PR TITLE
Feature: hide item in grid inventory when dragging

### DIFF
--- a/addons/gloot/ui/ctrl_inventory_grid_basic.gd
+++ b/addons/gloot/ui/ctrl_inventory_grid_basic.gd
@@ -120,6 +120,7 @@ func _ready() -> void:
 func _notification(what: int) -> void:
     if what == NOTIFICATION_DRAG_END:
         _ctrl_drop_zone.deactivate()
+        CtrlDragable.get_grabbed_dragable().show()
 
 
 func _connect_inventory_signals() -> void:
@@ -238,6 +239,7 @@ func _populate_list() -> void:
 
 
 func _on_item_grab(offset: Vector2, ctrl_inventory_item: CtrlInventoryItemRect) -> void:
+    CtrlDragable.get_grabbed_dragable().hide()
     _clear_selection()
 
 

--- a/addons/gloot/ui/ctrl_item_slot.gd
+++ b/addons/gloot/ui/ctrl_item_slot.gd
@@ -247,6 +247,7 @@ func _swap_items(item1: InventoryItem, item2: InventoryItem) -> bool:
 
 
 func _on_any_dragable_grabbed(dragable: CtrlDragable, grab_position: Vector2):
+    CtrlDragable.get_grabbed_dragable().show()
     _ctrl_drop_zone.activate()
 
 
@@ -266,6 +267,7 @@ func _on_mouse_exited():
 
 func _notification(what: int) -> void:
     if what == NOTIFICATION_DRAG_END:
+        CtrlDragable.get_grabbed_dragable().hide()
         _ctrl_drop_zone.deactivate()
 
 


### PR DESCRIPTION
## Description
Now when we grab item it will hide in grid but still present as drag preview attached to cursor. On drag end item will show again in inventory\slot grid.
## Notes
I`m not very familiar with source code so implementation may be not the best. Still all tests passed and feature works as intend. At least it my voice contribution to that this behaviour should be default.