### PR TITLE
add create_item(prototype_id) to inventory

### DIFF
--- a/addons/gloot/core/inventory.gd
+++ b/addons/gloot/core/inventory.gd
@@ -220,12 +220,17 @@ func can_add_item(item: InventoryItem) -> bool:
 func can_hold_item(item: InventoryItem) -> bool:
     return true
 
-## Creates an [InventoryItem] based on the given prototype ID and adds it to
-## the inventory. Returns [code]null[/code] if the item cannot be added.
-func create_and_add_item(prototype_id: String) -> InventoryItem:
+## Creates an [InventoryItem] based on the prototype ID.
+func create_item(prototype_id: String) ->InventoryItem:
     var item: InventoryItem = InventoryItem.new()
     item.protoset = item_protoset
     item.prototype_id = prototype_id
+    return item
+
+## Creates an [InventoryItem] based on the given prototype ID and adds it to
+## the inventory. Returns [code]null[/code] if the item cannot be added.
+func create_and_add_item(prototype_id: String) -> InventoryItem:
+    var item:InventoryItem = create_item(prototype_id)
     if add_item(item):
         return item
     else:

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -22,6 +22,7 @@ Basic inventory class. Supports basic inventory operations (adding, removing, tr
 * `can_hold_item(item: InventoryItem) -> bool` - Checks if the inventory can hold the given item. Always returns `true` and can be overridden to make the inventory only accept items with specific properties. Does not check inventory constraints such as capacity or grid space. Those checks are done by `can_add_item(item)`.
 * `can_add_item(item: InventoryItem) -> bool` - Checks if the given item can be added to the inventory taking inventory constraints (capacity, grid space etc.) and the result of `can_hold_item(item)` into account.
 * `add_item(item: InventoryItem) -> bool` - Adds the given item to the inventory.
+* `create_item(prototype_id: String) -> InventoryItem` - Creates an [InventoryItem] based on the prototype ID.
 * `create_and_add_item(prototype_id: String) -> InventoryItem` - Creates an `InventoryItem` based on the given prototype ID and adds it to the inventory. Returns `null` if the item cannot be added.
 * `remove_item(item: InventoryItem) -> bool` - Removes the given item from the inventory.
 * `remove_all_items() -> bool` - Removes the all items from the inventory.


### PR DESCRIPTION
Adds a method to create_item(protoset_id) with protoset_id, but **NOT** add the item to inventory; 

Use case: I want to create the item for a loot drop (which might have some unique properties set), but only add the item to inventory when the user presses a key/interacts with the loot drop. 

Note: I also use loot drop for the player dropping their own inventory on the ground which sets inventory_item_drop; in which case I just add_item back if they interact with it...


Example:
``` gd 
@onready var inventory_item_drop:InventoryItem

# Called when the node enters the scene tree for the first time.
func _ready() -> void:
	# utils.setup_node(self,"loot")
	if inventory_item_drop == null:
		inventory_item_drop= InventoryItem.new()
		inventory_item_drop = grid.create_item("bear_cape")
		# set unique item props

	pass # Replace with function body.

@onready var grid =  player.player_inventory.get_node("%character_inventory_grid") 
func _input(event: InputEvent) -> void:
	if Input.is_action_pressed("interact"):
		if item_loot_area.overlaps_body(player):
			if inventory_item_drop != null:
				if grid.can_add_item(inventory_item_drop):
					grid.add_item(inventory_item_drop)
					queue_free()
```
