### PR TITLE
Added drop items functionality at example scenes

### DIFF
--- a/examples/inventory_grid_stacked_transfer.gd
+++ b/examples/inventory_grid_stacked_transfer.gd
@@ -14,57 +14,65 @@ const info_offset: Vector2 = Vector2(20, 0)
 
 
 func _ready() -> void:
-    ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
-    ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
-    ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
-    ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
-    btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
-    btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
-    btn_split_left.pressed.connect(_on_btn_split.bind(ctrl_inventory_left))
-    btn_split_right.pressed.connect(_on_btn_split.bind(ctrl_inventory_right))
-    btn_unequip.pressed.connect(_on_btn_unequip)
+	ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
+	ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
+	ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
+	ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
+	btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
+	btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
+	btn_split_left.pressed.connect(_on_btn_split.bind(ctrl_inventory_left))
+	btn_split_right.pressed.connect(_on_btn_split.bind(ctrl_inventory_right))
+	btn_unequip.pressed.connect(_on_btn_unequip)
 
 
 func _on_item_mouse_entered(item: InventoryItem) -> void:
-    lbl_info.show()
-    lbl_info.text = item.prototype_id
+	lbl_info.show()
+	lbl_info.text = item.prototype_id
 
 
 func _on_item_mouse_exited(_item: InventoryItem) -> void:
-    lbl_info.hide()
+	lbl_info.hide()
 
 
 func _input(event: InputEvent) -> void:
-    if !(event is InputEventMouseMotion):
-        return
+	if !(event is InputEventMouseMotion):
+		return
 
-    lbl_info.set_global_position(get_global_mouse_position() + info_offset)
+	lbl_info.set_global_position(get_global_mouse_position() + info_offset)
 
+func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
+	return true
+
+func _drop_data(at_position: Vector2, data: Variant) -> void:
+	print("Item dropped: %s" % str(data.item))
+	ctrl_inventory_left.inventory.remove_item(data.item)
+	ctrl_inventory_right.inventory.remove_item(data.item)
+	#Custom logic for handling the item drop here 👈
 
 func _on_btn_sort(ctrl_inventory) -> void:
-    if !ctrl_inventory.inventory.sort():
-        print("Warning: InventoryGrid.sort() returned false!")
+	if !ctrl_inventory.inventory.sort():
+		print("Warning: InventoryGrid.sort() returned false!")
 
 
 func _on_btn_split(ctrl_inventory) -> void:
-    var inventory_stacked := (ctrl_inventory.inventory as InventoryGridStacked)
-    if inventory_stacked == null:
-        print("Warning: inventory is not InventoryGridStacked!")
-        return
+	var inventory_stacked := (ctrl_inventory.inventory as InventoryGridStacked)
+	if inventory_stacked == null:
+		print("Warning: inventory is not InventoryGridStacked!")
+		return
 
-    var selected_items = ctrl_inventory.get_selected_inventory_items()
-    if selected_items.is_empty():
-        return
+	var selected_items = ctrl_inventory.get_selected_inventory_items()
+	if selected_items.is_empty():
+		return
 
-    for selected_item in selected_items:
-        var stack_size := InventoryGridStacked.get_item_stack_size(selected_item)
-        if stack_size < 2:
-            return
+	for selected_item in selected_items:
+		var stack_size := InventoryGridStacked.get_item_stack_size(selected_item)
+		if stack_size < 2:
+			return
 
-        # All this floor/float jazz just to do integer division without warnings
-        var new_stack_size: int = floor(float(stack_size) / 2)
-        inventory_stacked.split(selected_item, new_stack_size)
+		# All this floor/float jazz just to do integer division without warnings
+		var new_stack_size: int = floor(float(stack_size) / 2)
+		inventory_stacked.split(selected_item, new_stack_size)
 
 
 func _on_btn_unequip() -> void:
-    ctrl_slot.item_slot.clear()
+	ctrl_slot.item_slot.clear()

--- a/examples/inventory_grid_stacked_transfer.gd
+++ b/examples/inventory_grid_stacked_transfer.gd
@@ -14,65 +14,64 @@ const info_offset: Vector2 = Vector2(20, 0)
 
 
 func _ready() -> void:
-	ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
-	ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
-	ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
-	ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
-	btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
-	btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
-	btn_split_left.pressed.connect(_on_btn_split.bind(ctrl_inventory_left))
-	btn_split_right.pressed.connect(_on_btn_split.bind(ctrl_inventory_right))
-	btn_unequip.pressed.connect(_on_btn_unequip)
+    ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
+    ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
+    ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
+    ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
+    btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
+    btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
+    btn_split_left.pressed.connect(_on_btn_split.bind(ctrl_inventory_left))
+    btn_split_right.pressed.connect(_on_btn_split.bind(ctrl_inventory_right))
+    btn_unequip.pressed.connect(_on_btn_unequip)
 
 
 func _on_item_mouse_entered(item: InventoryItem) -> void:
-	lbl_info.show()
-	lbl_info.text = item.prototype_id
+    lbl_info.show()
+    lbl_info.text = item.prototype_id
 
 
 func _on_item_mouse_exited(_item: InventoryItem) -> void:
-	lbl_info.hide()
+    lbl_info.hide()
 
 
 func _input(event: InputEvent) -> void:
-	if !(event is InputEventMouseMotion):
-		return
+    if !(event is InputEventMouseMotion):
+        return
 
-	lbl_info.set_global_position(get_global_mouse_position() + info_offset)
+    lbl_info.set_global_position(get_global_mouse_position() + info_offset)
 
 func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
-	return true
+    return true
 
 func _drop_data(at_position: Vector2, data: Variant) -> void:
-	print("Item dropped: %s" % str(data.item))
-	ctrl_inventory_left.inventory.remove_item(data.item)
-	ctrl_inventory_right.inventory.remove_item(data.item)
-	#Custom logic for handling the item drop here 👈
+    ctrl_inventory_left.inventory.remove_item(data.item)
+    ctrl_inventory_right.inventory.remove_item(data.item)
+    #Custom logic for handling the item drop here 👈
 
 func _on_btn_sort(ctrl_inventory) -> void:
-	if !ctrl_inventory.inventory.sort():
-		print("Warning: InventoryGrid.sort() returned false!")
+    if !ctrl_inventory.inventory.sort():
+        print("Warning: InventoryGrid.sort() returned false!")
 
 
 func _on_btn_split(ctrl_inventory) -> void:
-	var inventory_stacked := (ctrl_inventory.inventory as InventoryGridStacked)
-	if inventory_stacked == null:
-		print("Warning: inventory is not InventoryGridStacked!")
-		return
+    var inventory_stacked := (ctrl_inventory.inventory as InventoryGridStacked)
+    if inventory_stacked == null:
+        print("Warning: inventory is not InventoryGridStacked!")
+        return
 
-	var selected_items = ctrl_inventory.get_selected_inventory_items()
-	if selected_items.is_empty():
-		return
+    var selected_items = ctrl_inventory.get_selected_inventory_items()
+    if selected_items.is_empty():
+        return
 
-	for selected_item in selected_items:
-		var stack_size := InventoryGridStacked.get_item_stack_size(selected_item)
-		if stack_size < 2:
-			return
+    for selected_item in selected_items:
+        var stack_size := InventoryGridStacked.get_item_stack_size(selected_item)
+        if stack_size < 2:
+            return
 
-		# All this floor/float jazz just to do integer division without warnings
-		var new_stack_size: int = floor(float(stack_size) / 2)
-		inventory_stacked.split(selected_item, new_stack_size)
+        # All this floor/float jazz just to do integer division without warnings
+        var new_stack_size: int = floor(float(stack_size) / 2)
+        inventory_stacked.split(selected_item, new_stack_size)
 
 
 func _on_btn_unequip() -> void:
-	ctrl_slot.item_slot.clear()
+    ctrl_slot.item_slot.clear()

--- a/examples/inventory_grid_stacked_transfer.gd
+++ b/examples/inventory_grid_stacked_transfer.gd
@@ -46,7 +46,8 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 func _drop_data(at_position: Vector2, data: Variant) -> void:
     ctrl_inventory_left.inventory.remove_item(data.item)
     ctrl_inventory_right.inventory.remove_item(data.item)
-    #Custom logic for handling the item drop here 👈
+    # Replace the following line with custom logic for handling the item drop:
+    data.item.queue_free()
 
 func _on_btn_sort(ctrl_inventory) -> void:
     if !ctrl_inventory.inventory.sort():

--- a/examples/inventory_grid_transfer.gd
+++ b/examples/inventory_grid_transfer.gd
@@ -42,7 +42,8 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 func _drop_data(at_position: Vector2, data: Variant) -> void:
     ctrl_inventory_left.inventory.remove_item(data.item)
     ctrl_inventory_right.inventory.remove_item(data.item)
-    #Custom logic for handling the item drop here 👈
+    # Replace the following line with custom logic for handling the item drop:
+    data.item.queue_free()
 
 func _on_btn_sort(ctrl_inventory) -> void:
     if !ctrl_inventory.inventory.sort():

--- a/examples/inventory_grid_transfer.gd
+++ b/examples/inventory_grid_transfer.gd
@@ -12,43 +12,42 @@ const info_offset: Vector2 = Vector2(20, 0)
 
 
 func _ready() -> void:
-	ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
-	ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
-	ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
-	ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
-	btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
-	btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
-	btn_unequip.pressed.connect(_on_btn_unequip)
+    ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
+    ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
+    ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
+    ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
+    btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
+    btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
+    btn_unequip.pressed.connect(_on_btn_unequip)
 
 
 func _on_item_mouse_entered(item: InventoryItem) -> void:
-	lbl_info.show()
-	lbl_info.text = item.prototype_id
+    lbl_info.show()
+    lbl_info.text = item.prototype_id
 
 
 func _on_item_mouse_exited(_item: InventoryItem) -> void:
-	lbl_info.hide()
+    lbl_info.hide()
 
 
 func _input(event: InputEvent) -> void:
-	if !(event is InputEventMouseMotion):
-		return
+    if !(event is InputEventMouseMotion):
+        return
 
-	lbl_info.set_global_position(get_global_mouse_position() + info_offset)
+    lbl_info.set_global_position(get_global_mouse_position() + info_offset)
 
 func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
-	return true
+    return true
 
 func _drop_data(at_position: Vector2, data: Variant) -> void:
-	print("Item dropped: %s" % str(data.item))
-	ctrl_inventory_left.inventory.remove_item(data.item)
-	ctrl_inventory_right.inventory.remove_item(data.item)
-	#Custom logic for handling the item drop here 👈
+    ctrl_inventory_left.inventory.remove_item(data.item)
+    ctrl_inventory_right.inventory.remove_item(data.item)
+    #Custom logic for handling the item drop here 👈
 
 func _on_btn_sort(ctrl_inventory) -> void:
-	if !ctrl_inventory.inventory.sort():
-		print("Warning: InventoryGrid.sort() returned false!")
+    if !ctrl_inventory.inventory.sort():
+        print("Warning: InventoryGrid.sort() returned false!")
 
 
 func _on_btn_unequip() -> void:
-	ctrl_slot.item_slot.clear()
+    ctrl_slot.item_slot.clear()

--- a/examples/inventory_grid_transfer.gd
+++ b/examples/inventory_grid_transfer.gd
@@ -12,35 +12,43 @@ const info_offset: Vector2 = Vector2(20, 0)
 
 
 func _ready() -> void:
-    ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
-    ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
-    ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
-    ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
-    btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
-    btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
-    btn_unequip.pressed.connect(_on_btn_unequip)
+	ctrl_inventory_left.item_mouse_entered.connect(_on_item_mouse_entered)
+	ctrl_inventory_left.item_mouse_exited.connect(_on_item_mouse_exited)
+	ctrl_inventory_right.item_mouse_entered.connect(_on_item_mouse_entered)
+	ctrl_inventory_right.item_mouse_exited.connect(_on_item_mouse_exited)
+	btn_sort_left.pressed.connect(_on_btn_sort.bind(ctrl_inventory_left))
+	btn_sort_right.pressed.connect(_on_btn_sort.bind(ctrl_inventory_right))
+	btn_unequip.pressed.connect(_on_btn_unequip)
 
 
 func _on_item_mouse_entered(item: InventoryItem) -> void:
-    lbl_info.show()
-    lbl_info.text = item.prototype_id
+	lbl_info.show()
+	lbl_info.text = item.prototype_id
 
 
 func _on_item_mouse_exited(_item: InventoryItem) -> void:
-    lbl_info.hide()
+	lbl_info.hide()
 
 
 func _input(event: InputEvent) -> void:
-    if !(event is InputEventMouseMotion):
-        return
+	if !(event is InputEventMouseMotion):
+		return
 
-    lbl_info.set_global_position(get_global_mouse_position() + info_offset)
+	lbl_info.set_global_position(get_global_mouse_position() + info_offset)
 
+func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
+	return true
+
+func _drop_data(at_position: Vector2, data: Variant) -> void:
+	print("Item dropped: %s" % str(data.item))
+	ctrl_inventory_left.inventory.remove_item(data.item)
+	ctrl_inventory_right.inventory.remove_item(data.item)
+	#Custom logic for handling the item drop here 👈
 
 func _on_btn_sort(ctrl_inventory) -> void:
-    if !ctrl_inventory.inventory.sort():
-        print("Warning: InventoryGrid.sort() returned false!")
+	if !ctrl_inventory.inventory.sort():
+		print("Warning: InventoryGrid.sort() returned false!")
 
 
 func _on_btn_unequip() -> void:
-    ctrl_slot.item_slot.clear()
+	ctrl_slot.item_slot.clear()


### PR DESCRIPTION
Solves #236 by implementing the solution @peter-kish suggested

Btw, the indentations in all of this project are spaces instead of tabs. So this PR which is just 20 lines added, ends up changing the indentations for all files. I used Godot 4.3 stable to make this PR, is there a version which doesn't automatically change these indentations? These 4 spacebars do work and are detected by Godot as valid after all.