### PR TITLE
Avoid overriding the default texture with an empty image

### DIFF
--- a/addons/gloot/ui/ctrl_inventory_item_rect.gd
+++ b/addons/gloot/ui/ctrl_inventory_item_rect.gd
@@ -18,7 +18,8 @@ var item: InventoryItem:
 
         item = new_item
         if item:
-            texture = item.get_texture()
+            var item_texture: Texture2D = item.get_texture()
+            texture = item_texture if item_texture else texture
             activate()
         else:
             texture = null


### PR DESCRIPTION
In this section
https://github.com/peter-kish/gloot/blob/b20da4bc8d631b47d033bedb6d69405e3fd0d78f/addons/gloot/ui/ctrl_inventory_grid_basic.gd#L221-L222 

The default texture is applied first, and then the item is applied 

However, the item texture is overridden even if it has no image 

This change makes it so that if the item has no texture, it doesn't override the image

fixes #257 