### PR TITLE
Fixed issue with ItemCountConstraint which prevented adding new items. [3.0.0]

### DIFF
--- a/addons/gloot/core/constraints/item_count_constraint.gd
+++ b/addons/gloot/core/constraints/item_count_constraint.gd
@@ -52,7 +52,7 @@ func get_space_for(item: InventoryItem) -> int:
 
 ## Checks if the constraint can receive the given item.
 func has_space_for(item: InventoryItem) -> bool:
-    return get_occupied_space() <= capacity && get_space_for(item) > 0
+    return get_occupied_space() < capacity || get_space_for(item) > 0
 
 
 ## Resets the constraint, i.e. sets its capacity to default (`1`).

--- a/addons/gloot/core/constraints/item_count_constraint.gd
+++ b/addons/gloot/core/constraints/item_count_constraint.gd
@@ -52,7 +52,7 @@ func get_space_for(item: InventoryItem) -> int:
 
 ## Checks if the constraint can receive the given item.
 func has_space_for(item: InventoryItem) -> bool:
-    return get_occupied_space() < capacity
+    return get_occupied_space() <= capacity && get_space_for(item) > 0
 
 
 ## Resets the constraint, i.e. sets its capacity to default (`1`).

--- a/addons/gloot/core/constraints/item_count_constraint.gd
+++ b/addons/gloot/core/constraints/item_count_constraint.gd
@@ -2,9 +2,9 @@
 @icon("res://addons/gloot/images/icon_item_count_constraint.svg")
 extends InventoryConstraint
 class_name ItemCountConstraint
-## A constraint that limits the inventory to a given item count.
+## A constraint that limits the inventory to a given item stack count.
 ##
-## The constraint implements a count-based inventory where the total number of items cannot exceed the configured
+## The constraint implements a count-based inventory where the total number of item stacks cannot exceed the configured
 ## capacity of the inventory.
 
 const _Verify = preload("res://addons/gloot/core/verify.gd")
@@ -14,7 +14,7 @@ const DEFAULT_CAPACITY = 1
 
 const _KEY_CAPACITY: String = "capacity"
 
-## Maximum number of items the inventory can hold.
+## Maximum number of item stacks the inventory can hold.
 @export var capacity: int = DEFAULT_CAPACITY:
     set(new_capacity):
         if new_capacity < 1:
@@ -27,12 +27,12 @@ const _KEY_CAPACITY: String = "capacity"
         changed.emit()
 
 
-## Returns the number of items that can be added to the inventory.
+## Returns the number of item stacks that can be added to the inventory.
 func get_free_space() -> int:
     return max(0, capacity - get_occupied_space())
 
 
-## Returns the total number of items in the inventory.
+## Returns the total number of item stacks in the inventory.
 func get_occupied_space() -> int:
     if !is_instance_valid(inventory):
         return 0


### PR DESCRIPTION
This fixes the problem with ItemCountConstraint which prevented new items from being added if capacity was full but the existing item stack in the inventory was not full. Also rewords the comments to make it clear that capacity and free space refers to the number of individual item stacks, and not actually how many items exists.