### PR TITLE
[Prototype] Add default_value if no parent have the property

### DIFF
--- a/addons/gloot/core/prototree/prototype.gd
+++ b/addons/gloot/core/prototree/prototype.gd
@@ -68,7 +68,7 @@ func get_property(property: String, default_value: Variant = null) -> Variant:
     if _properties.has(property):
         return _properties[property]
     if is_instance_valid(_parent):
-        return _parent.get_property(property)
+        return _parent.get_property(property, default_value)
     return default_value
 
 


### PR DESCRIPTION
About the following method : 
```gdscript
get_property(property: String, default_value: Variant = null) -> Variant:
```
If the protype don't have the requested property and either one of his parent the default_value is not returned, we get null instead.

Maybe it's was expected, in that case feel free to close that PR