### PR TITLE
#284 Drag and drop area detection

### DIFF
--- a/addons/gloot/ui/ctrl_draggable_inventory_item.gd
+++ b/addons/gloot/ui/ctrl_draggable_inventory_item.gd
@@ -54,18 +54,29 @@ func _notification(what: int) -> void:
 
 
 func _get_drag_data(at_position: Vector2) -> Variant:
+    
     if item == null:
         return null
-        
-    _grab_offset = at_position * get_global_transform().get_scale()
-
+    
+    scale = get_global_transform().get_scale() 
+    var size: Vector2 = _ctrl_inventory_item.size 
+    var scaled_size: Vector2 = scale * size 
+    var scaled_pos: Vector2  = scale * at_position
+    _grab_offset = scaled_pos / size + scaled_size / 2
+    
     var sub_preview: Control = null
+    
     sub_preview = _create_preview()
+    
     if sub_preview == null:
         return null
+        
     var preview = Control.new()
+    
     sub_preview.position = -_grab_offset
+    
     preview.add_child(sub_preview)
+    
     set_drag_preview(preview)
 
     return item

--- a/addons/gloot/ui/ctrl_draggable_inventory_item.gd
+++ b/addons/gloot/ui/ctrl_draggable_inventory_item.gd
@@ -58,11 +58,11 @@ func _get_drag_data(at_position: Vector2) -> Variant:
     if item == null:
         return null
     
-    scale = get_global_transform().get_scale() 
-    var size: Vector2 = _ctrl_inventory_item.size 
-    var scaled_size: Vector2 = scale * size 
-    var scaled_pos: Vector2  = scale * at_position
-    _grab_offset = scaled_pos / size + scaled_size / 2
+    var item_scale: Vector2 = get_global_transform().get_scale() 
+    var item_size: Vector2 = _ctrl_inventory_item.size 
+    var scaled_size: Vector2 = item_scale * item_size 
+    var scaled_pos: Vector2  = item_scale * at_position
+    _grab_offset = scaled_pos / item_size + scaled_size / 2
     
     var sub_preview: Control = null
     


### PR DESCRIPTION
Fixed issue #284. I'm sure there is a better way to calculate the offset based on the selected item's image (preview) size, but this is an OK solution as item dragging is rarely done at the same time as other heavy computations, and only calculated once.

Note: Only tested on inventory_grid_stacked_transfer and with all unittests.